### PR TITLE
docs: clarify curriculum overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,40 @@
-# AI Engineering Curriculum (AIFB-style) — gpt-5-codex
+# Path to GenAI Expert
 
-A clear, topic-first curriculum inspired by the style of **AI-For-Beginners**. Short modules, hands-on labs, and space to link **my own projects** next to each topic.
+A curated, topic-first learning path to take me from AI fundamentals to leading production-grade AI projects. Each module combines focused study with a real-world demo that proves out the concepts and captures measurable outcomes (latency, cost, accuracy).
 
-> Tip: Pick one primary resource per module, build a small demo, and record key metrics (latency/cost/accuracy) in your project README.
+## How this repository is organized
+- **Vision** – why this roadmap exists and the kind of expert I aim to become.
+- **Learning path** – the ordered list of modules. Every row explains the key skills and gives me a space to link the demo project that showcases them.
+- **How to use** – a repeatable workflow for working through the material and building demos.
 
-## Learning Path (beginner → production)
+## Vision: build, measure, lead
+1. Develop strong theoretical footing in generative AI and adjacent disciplines.
+2. Ship hands-on demos that solve real problems and document the metrics that matter.
+3. Grow the collection into a portfolio that demonstrates leadership in AI delivery.
 
-| # | Module | What you'll learn | **My project** |
-|---|---|---|---|
-| 00 | [Introduction](curriculum/00-introduction/README.md) | Repo purpose, how to use this curriculum | *(add link)* |
-| 01 | [GenAI & LLM Fundamentals](curriculum/01-genai-fundamentals/README.md) | tokens, context windows, embeddings, model lifecycle | *(add link)* |
-| 02 | [Prompting & Structured Outputs](curriculum/02-prompting-structured-outputs/README.md) | prompting patterns, JSON/schema outputs, function calling | *(add link)* |
-| 03 | [Agents & Orchestration](curriculum/03-agents-orchestration/README.md) | tool schemas, planning loops, guardrails | *(add link)* |
-| 04 | [RAG Essentials](curriculum/04-rag-essentials/README.md) | chunking, embeddings, hybrid search, reranking | *(add link)* |
-| 05 | [Evaluation & Observability](curriculum/05-evaluation-observability/README.md) | golden sets, faithfulness, Recall@k, traces, cost dashboards | *(add link)* |
-| 06 | [Serving & Inference](curriculum/06-serving-inference/README.md) | servers, gateways, batching, streaming | *(add link)* |
-| 07 | [Performance & Cost Optimization](curriculum/07-performance-optimization/README.md) | quantization, KV cache, speculative decoding, LoRA/distill | *(add link)* |
-| 08 | [Vector Search](curriculum/08-vector-search/README.md) | FAISS/pgvector/Milvus, HNSW/IVF, hybrid search | *(add link)* |
-| 09 | [Security & Safety](curriculum/09-security-safety/README.md) | prompt injection, insecure output handling, permissions | *(add link)* |
-| 10 | [Governance & Compliance](curriculum/10-governance-compliance/README.md) | NIST AI RMF, EU AI Act basics, model cards | *(add link)* |
-| 11 | [Edge & Embedded (Optional)](curriculum/11-edge-embedded/README.md) | SLMs on-device, offline modes, tests | *(add link)* |
-| 12 | [Portfolio Patterns](curriculum/12-portfolio-patterns/README.md) | small demos that prove skills with metrics | *(add link)* |
+## Learning path (beginner → production)
+| #  | Module | Focus of the module | Demo project (add link when ready) |
+|----|--------|---------------------|------------------------------------|
+| 00 | [Introduction](curriculum/00-introduction/README.md) | Purpose of the repo, study habits, tooling setup. | *(add link)* |
+| 01 | [GenAI & LLM Fundamentals](curriculum/01-genai-fundamentals/README.md) | Tokenization, context windows, embeddings, model lifecycle. | *(add link)* |
+| 02 | [Prompting & Structured Outputs](curriculum/02-prompting-structured-outputs/README.md) | Prompt design patterns, JSON/schema outputs, function calling. | *(add link)* |
+| 03 | [Agents & Orchestration](curriculum/03-agents-orchestration/README.md) | Planning loops, tool schemas, guardrails and safety checks. | *(add link)* |
+| 04 | [RAG Essentials](curriculum/04-rag-essentials/README.md) | Chunking strategies, hybrid retrieval, reranking, evaluations. | *(add link)* |
+| 05 | [Evaluation & Observability](curriculum/05-evaluation-observability/README.md) | Golden datasets, faithfulness metrics, tracing and dashboards. | *(add link)* |
+| 06 | [Serving & Inference](curriculum/06-serving-inference/README.md) | Hosting models, gateways, batching, streaming responses. | *(add link)* |
+| 07 | [Performance & Cost Optimization](curriculum/07-performance-optimization/README.md) | Quantization, KV cache usage, speculative decoding, fine-tuning. | *(add link)* |
+| 08 | [Vector Search](curriculum/08-vector-search/README.md) | FAISS/pgvector/Milvus, indexing algorithms, hybrid retrieval. | *(add link)* |
+| 09 | [Security & Safety](curriculum/09-security-safety/README.md) | Prompt injection defenses, secure output handling, permissions. | *(add link)* |
+| 10 | [Governance & Compliance](curriculum/10-governance-compliance/README.md) | NIST AI RMF, EU AI Act basics, model documentation practices. | *(add link)* |
+| 11 | [Edge & Embedded (Optional)](curriculum/11-edge-embedded/README.md) | Running SLMs on-device, offline modes, hardware-aware testing. | *(add link)* |
+| 12 | [Portfolio Patterns](curriculum/12-portfolio-patterns/README.md) | Demo blueprints, storytelling with metrics, packaging results. | *(add link)* |
 
-## How to use
-1. Open a module, read the short overview, and pick **one** primary resource.
-2. Build a tiny demo; link it back in this table under **My project**.
-3. Capture lessons learned and numbers (latency/cost/accuracy).
+> **Tip:** Keep each demo small but production-minded—add telemetry, track budget, and note trade-offs.
+
+## How to use this roadmap
+1. **Review the module overview.** Skim the curated resources and choose one primary source to study deeply.
+2. **Design a demo.** Pick a real-world problem, scope it to a weekend project, and define success metrics.
+3. **Build and document.** Implement the demo, record latency/cost/quality numbers, and link the repo or notebook in the table above.
+4. **Reflect and iterate.** Write down lessons learned, gaps to fill, and ideas for the next module.
 
 — gpt-5-codex


### PR DESCRIPTION
## Summary
- rewrite the README introduction to highlight the goal of becoming a GenAI expert through focused modules and demos
- explain each section of the repository so the roadmap is easier to navigate
- refresh the module table with clearer descriptions and guidance for linking future demo projects

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2dcff66d8832dbe7d37eb18c8e841