### PR TITLE
Add project templates and finalize curriculum assets

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,45 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+We as members, contributors, and leaders pledge to make participation in this project and our community a harassment-free experience for everyone, regardless of age, body size, disability, visible or invisible identity, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+Examples of behavior that contributes to a positive environment for our community include:
+- Demonstrating empathy and kindness toward other people.
+- Being respectful of differing opinions, viewpoints, and experiences.
+- Giving and gracefully accepting constructive feedback.
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience.
+- Focusing on what is best not just for us as individuals, but for the overall community.
+
+Examples of unacceptable behavior include:
+- The use of sexualized language or imagery, and sexual attention or advances of any kind.
+- Trolling, insulting or derogatory comments, and personal or political attacks.
+- Public or private harassment.
+- Publishing others’ private information, such as a physical or email address, without their explicit permission.
+- Other conduct which could reasonably be considered inappropriate in a professional setting.
+
+## Enforcement Responsibilities
+Project maintainers are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+This Code of Conduct applies within all project spaces, and also applies when an individual is officially representing the project in public spaces.
+
+## Enforcement
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the maintainers via GitHub issues or email. All complaints will be reviewed and investigated promptly and fairly.
+
+All project maintainers are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+Project maintainers will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+1. **Correction** – Community Impact: Use of inappropriate language or other behavior deemed unprofessional. Consequence: A private, written warning from project maintainers, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate.
+2. **Warning** – Community Impact: A violation through a single incident or series of actions. Consequence: A warning with consequences for continued behavior.
+3. **Temporary Ban** – Community Impact: A serious violation of community standards, including sustained inappropriate behavior. Consequence: A temporary ban from any sort of interaction or public communication with the community.
+4. **Permanent Ban** – Community Impact: Demonstrating a pattern of violation or harassment. Consequence: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org) version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing Guide
+
+Thank you for helping grow *Path to GenAI Expert*! This project aims to be a living curriculum that balances hands-on builds, governance rigor, and leadership skills. Please follow the guidelines below to keep contributions consistent and high quality.
+
+## How to Propose Updates
+1. **Open an issue first.** Describe the improvement (new resource, module update, template fix) and link to any references.
+2. **Fork and branch.** Use descriptive branch names (e.g., `feature/new-rag-resource`) and keep changes focused.
+3. **Add evidence.** When adding or updating resources, include why they matter, estimated time, and proof that links work.
+4. **Run checks.** Validate that Markdown renders, links resolve, and templates remain copy-paste ready.
+5. **Submit a PR.** Fill out the pull request template (coming soon) and link the issue you opened. Expect review feedback within a few days.
+
+## Style Rules
+- Follow the tone of the README: concise, pragmatic, leadership-aware.
+- Use active voice, actionable verbs, and inclusive language.
+- Keep Markdown headings to three levels deep within README modules.
+- Tables should include: Resource, Format, Level, Estimated Time, and Why it matters.
+- Add a **Mini-task** and an `<!-- TODO: Extend later -->` block for every new section.
+
+## Resource Quality Bar
+- Prefer official documentation, reputable courses, or well-maintained open-source repos updated within the last 18 months.
+- Avoid paywalled resources unless a generous free tier exists—mark any costs clearly.
+- Link-check before submission and include a short justification (1–2 sentences) explaining why the resource is valuable.
+- Do not duplicate resources already listed elsewhere in the curriculum.
+
+## Pull Request Checklist
+- [ ] Issue linked and scope agreed with maintainers.
+- [ ] README sections updated with description, resource table, mini-task, and TODO block.
+- [ ] Templates (if touched) remain functional and use Markdown tables where helpful.
+- [ ] `RESOURCES.json` updated to include any new resources with metadata.
+- [ ] Links validated and spelling/grammar checked.
+- [ ] CI (if enabled) passes and new content follows style guidelines.
+
+By contributing you agree to the [MIT License](LICENSE) and the [Code of Conduct](CODE_OF_CONDUCT.md). We’re excited to learn from your experience!

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/PROJECT_TEMPLATES/EXPERIMENT_LOG.md
+++ b/PROJECT_TEMPLATES/EXPERIMENT_LOG.md
@@ -1,0 +1,50 @@
+# Experiment Log Template
+
+Use this log to capture every experiment, prompt iteration, or model evaluation. Duplicate the table per run.
+
+## Experiment Metadata
+- **Experiment ID:** `YYYYMMDD-<short-name>`
+- **Owner:**
+- **Related project / issue:**
+- **Hypothesis:** What are you trying to learn or improve?
+- **Baseline reference:** Link to prior run or control.
+
+## Configuration Snapshot
+| Parameter | Value |
+|-----------|-------|
+| Model / version |
+| Prompt / system message |
+| Retrieval config (if RAG) |
+| Temperature / top-p / top-k |
+| Max tokens |
+| Tooling / agents |
+| Dataset slice |
+| Hardware |
+| Cost controls |
+
+## Procedure
+1. **Setup:** Describe data prep, environment, and scripts used.
+2. **Run steps:** Bullet the sequence of actions.
+3. **Observability:** Note logging, tracing, telemetry captured.
+
+## Results
+| Metric | Score | Target | Delta vs. Baseline |
+|--------|-------|--------|---------------------|
+| | | | |
+
+- **Qualitative notes:** Annotate failure modes, standout examples, user feedback.
+- **Cost & latency:** Record per-call cost, throughput, GPU utilization.
+- **Artifacts:** Links to notebooks, dashboards, pull requests.
+
+## Decision
+- **Outcome:** ▢ Accept ▢ Reject ▢ Needs follow-up
+- **Next actions:** What should happen next? Include owners and due dates.
+- **Risks / blockers:** Items to escalate.
+
+## Reflection
+- **What worked:**
+- **What to improve:**
+- **Questions for mentors / stakeholders:**
+
+---
+- **Log updated:**

--- a/PROJECT_TEMPLATES/MODEL_CARD.md
+++ b/PROJECT_TEMPLATES/MODEL_CARD.md
@@ -1,0 +1,54 @@
+# Model Card Template
+
+Summarize model intent, data lineage, evaluation, and caveats. Update this card whenever you ship a new version.
+
+## 1. Model Overview
+- **Model name / version:**
+- **Release date:**
+- **Authors / owners:**
+- **Intended use cases:** List supported tasks and audiences.
+- **Out-of-scope uses:** Explicitly state disallowed or unsafe scenarios.
+
+## 2. Model Details
+- **Base model / architecture:** Include size, provider, license.
+- **Adaptation method:** Prompt-engineering, fine-tuning, LoRA/QLoRA, RLHF, etc.
+- **Training / adaptation codebase:** Link to repo or scripts.
+- **Hyperparameters:** Batch size, lr, max length, temperature, etc.
+- **Compute footprint:** Hardware, GPU hours, energy estimates if available.
+
+## 3. Data
+- **Sources:** Datasets, internal corpora, scraping notes, collection dates.
+- **Preprocessing:** Cleaning, filtering, chunking, augmentation steps.
+- **Data balancing:** Coverage across domains, demographics, languages.
+- **Sensitive attributes handled:** How bias and privacy were addressed.
+- **Data quality checks:** Manual review, automated validation, lineage tracking.
+
+## 4. Evaluation
+| Task | Dataset / Split | Metric | Score | Threshold | Notes |
+|------|-----------------|--------|-------|-----------|-------|
+| Example | | | | | |
+
+- **Prompt/RAG evals:** Describe rubrics, judges, cost/latency budgets.
+- **Human evaluation:** SME reviewers, sample size, agreement scores.
+- **Drift monitoring:** Tests scheduled post-launch, triggers for rollback.
+
+## 5. Limitations & Risks
+- **Known failure modes:** e.g., hallucinations, refusal to comply.
+- **Bias & fairness concerns:** Populations or topics requiring caution.
+- **Security considerations:** Prompt injection susceptibility, data leakage risks.
+- **Mitigations:** Filters, guardrails, fallback flows, human-in-the-loop.
+
+## 6. Usage Guidelines
+- **Integration instructions:** APIs, SDKs, environment variables.
+- **Input constraints:** Token limits, content restrictions.
+- **Output post-processing:** Validation, moderation, grounding steps.
+- **Support / escalation:** On-call contact, response SLA, incident playbook.
+
+## 7. Version History
+| Version | Date | Changes | Owner | Notes |
+|---------|------|---------|-------|-------|
+| 1.0 |
+
+---
+- **Last reviewed:**
+- **Next review date:**

--- a/PROJECT_TEMPLATES/PROJECT_BRIEF.md
+++ b/PROJECT_TEMPLATES/PROJECT_BRIEF.md
@@ -1,0 +1,74 @@
+# Project Brief Template
+
+Use this template to scope GenAI initiatives before committing engineering time. Keep it to 2–3 pages and link supporting docs instead of embedding them.
+
+## 1. Project Snapshot
+- **Project name:**
+- **Prepared by / Date:**
+- **Phase:** ▢ Discovery ▢ Scoping ▢ Delivery ▢ Launch ▢ Sustain
+- **Linked experiment log:**
+- **Related issues / OKRs:**
+
+## 2. Problem & Context
+- **Business problem:** What pain or opportunity does this address?
+- **Target users / stakeholders:** Who benefits? Who signs off?
+- **Current workflows:** What is happening today? Include baseline metrics.
+- **Strategic alignment:** How does this support org goals or KPIs?
+
+## 3. Success Criteria
+- **Primary metric(s):** Quality, latency, cost, satisfaction, risk reduced, etc.
+- **Guardrails:** Maximum latency, budget, legal or policy constraints.
+- **Definition of done:** Checklist of what must be true for launch approval.
+
+## 4. Solution Outline
+- **User journey / scenarios:** Bullet the key interactions.
+- **Architecture sketch:** Link to diagram or describe components (prompting, RAG, fine-tuning, agents, integrations).
+- **Data sources:** Internal / external datasets, refresh cadence, privacy considerations.
+- **Model strategy:** Prompt-only, RAG-first, fine-tune, hybrid. Note reasoning.
+
+## 5. Delivery Plan
+| Milestone | Owner | Deliverable | Target date | Dependencies |
+|-----------|-------|-------------|-------------|--------------|
+| Kickoff |
+| Prototype |
+| Evaluation | 
+| Pilot |
+| Launch |
+
+- **Review cadence:** Standups, demos, stakeholder readouts.
+- **Tooling:** Tracking (Notion/Jira), experiment logging, observability stack.
+
+## 6. Evaluation Plan
+- **Offline metrics:** e.g., BLEU, ROUGE, accuracy, F1, retrieval hit rate.
+- **Online metrics:** e.g., CSAT, retention, task completion time.
+- **Qualitative review:** SMEs, red-teaming, LLM-as-judge with human audit frequency.
+- **Regression plan:** Link to evaluation scripts and acceptance thresholds.
+
+## 7. Risks & Mitigations
+| Risk | Impact | Likelihood | Mitigation | Owner |
+|------|--------|------------|------------|-------|
+| Data quality |
+| Prompt injection |
+| Cost overrun |
+| Stakeholder adoption |
+
+- **Open questions:**
+
+## 8. Compliance & Safety
+- **PII/Sensitive data handling:** Masking, encryption, retention.
+- **Responsible AI review:** Bias checks, hallucination guardrails, escalation path.
+- **Security requirements:** Secrets management, API scopes, access control.
+
+## 9. Launch Readiness
+- **Documentation:** User guides, runbooks, model cards.
+- **Training / enablement:** Sessions scheduled? Materials linked?
+- **Support model:** Owners for monitoring, incident response, feedback triage.
+
+## 10. Post-Launch Plan
+- **Success measurement window:** How long until final evaluation?
+- **Iteration backlog:** Next experiments, stretch goals, phased rollout.
+- **Sunset criteria:** When do we retire or replace this solution?
+
+---
+- **Last reviewed:**
+- **Next review date:**

--- a/README.md
+++ b/README.md
@@ -1,40 +1,729 @@
 # Path to GenAI Expert
 
-A curated, topic-first learning path to take me from AI fundamentals to leading production-grade AI projects. Each module combines focused study with a real-world demo that proves out the concepts and captures measurable outcomes (latency, cost, accuracy).
+> A paced, portfolio-focused curriculum for engineers who want to master generative AI and lead delivery-ready AI programs.
 
-## How this repository is organized
-- **Vision** – why this roadmap exists and the kind of expert I aim to become.
-- **Learning path** – the ordered list of modules. Every row explains the key skills and gives me a space to link the demo project that showcases them.
-- **How to use** – a repeatable workflow for working through the material and building demos.
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE) [![GitHub stars](https://img.shields.io/github/stars/manju89jay/path-to-genai-expert.svg?style=social)](https://github.com/manju89jay/path-to-genai-expert/stargazers) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 
-## Vision: build, measure, lead
-1. Develop strong theoretical footing in generative AI and adjacent disciplines.
-2. Ship hands-on demos that solve real problems and document the metrics that matter.
-3. Grow the collection into a portfolio that demonstrates leadership in AI delivery.
+```mermaid
+graph LR
+    A([Kickoff]) --> B([Build Foundations])
+    B --> C([Ship Integrated Systems])
+    C --> D([Scale & Govern])
+    D --> E([Lead & Mentor])
+    style A fill:#dbeafe,stroke:#1d4ed8
+    style B fill:#dcfce7,stroke:#15803d
+    style C fill:#fef3c7,stroke:#b45309
+    style D fill:#fee2e2,stroke:#b91c1c
+    style E fill:#ede9fe,stroke:#6d28d9
+```
 
-## Learning path (beginner → production)
-| #  | Module | Focus of the module | Demo project (add link when ready) |
-|----|--------|---------------------|------------------------------------|
-| 00 | [Introduction](curriculum/00-introduction/README.md) | Purpose of the repo, study habits, tooling setup. | *(add link)* |
-| 01 | [GenAI & LLM Fundamentals](curriculum/01-genai-fundamentals/README.md) | Tokenization, context windows, embeddings, model lifecycle. | *(add link)* |
-| 02 | [Prompting & Structured Outputs](curriculum/02-prompting-structured-outputs/README.md) | Prompt design patterns, JSON/schema outputs, function calling. | *(add link)* |
-| 03 | [Agents & Orchestration](curriculum/03-agents-orchestration/README.md) | Planning loops, tool schemas, guardrails and safety checks. | *(add link)* |
-| 04 | [RAG Essentials](curriculum/04-rag-essentials/README.md) | Chunking strategies, hybrid retrieval, reranking, evaluations. | *(add link)* |
-| 05 | [Evaluation & Observability](curriculum/05-evaluation-observability/README.md) | Golden datasets, faithfulness metrics, tracing and dashboards. | *(add link)* |
-| 06 | [Serving & Inference](curriculum/06-serving-inference/README.md) | Hosting models, gateways, batching, streaming responses. | *(add link)* |
-| 07 | [Performance & Cost Optimization](curriculum/07-performance-optimization/README.md) | Quantization, KV cache usage, speculative decoding, fine-tuning. | *(add link)* |
-| 08 | [Vector Search](curriculum/08-vector-search/README.md) | FAISS/pgvector/Milvus, indexing algorithms, hybrid retrieval. | *(add link)* |
-| 09 | [Security & Safety](curriculum/09-security-safety/README.md) | Prompt injection defenses, secure output handling, permissions. | *(add link)* |
-| 10 | [Governance & Compliance](curriculum/10-governance-compliance/README.md) | NIST AI RMF, EU AI Act basics, model documentation practices. | *(add link)* |
-| 11 | [Edge & Embedded (Optional)](curriculum/11-edge-embedded/README.md) | Running SLMs on-device, offline modes, hardware-aware testing. | *(add link)* |
-| 12 | [Portfolio Patterns](curriculum/12-portfolio-patterns/README.md) | Demo blueprints, storytelling with metrics, packaging results. | *(add link)* |
+## Table of Contents
+- [How to Use This Repo](#how-to-use-this-repo)
+- [Learning Path Overview](#learning-path-overview)
+- [Phase 0 – Orientation](#phase-0--orientation)
+  - [Orientation & Study Plan](#orientation--study-plan)
+  - [Module 00 · Introduction](#module-00--introduction)
+- [Phase 1 – Foundations](#phase-1--foundations)
+  - [Module 01 · GenAI Fundamentals](#module-01--genai-fundamentals)
+  - [Math for GenAI](#math-for-genai)
+  - [Module 02 · Prompting & Structured Outputs](#module-02--prompting--structured-outputs)
+  - [Prompt Engineering Essentials](#prompt-engineering-essentials)
+- [Phase 2 – Orchestration & Knowledge Systems](#phase-2--orchestration--knowledge-systems)
+  - [Module 03 · Agents & Orchestration](#module-03--agents--orchestration)
+  - [Agents & Tool-Use](#agents--tool-use)
+  - [Module 04 · RAG Essentials](#module-04--rag-essentials)
+  - [Retrieval-Augmented Generation](#retrieval-augmented-generation)
+  - [Module 05 · Evaluation & Observability](#module-05--evaluation--observability)
+  - [Evaluation & Evals](#evaluation--evals)
+- [Phase 3 – Deployment & Optimization](#phase-3--deployment--optimization)
+  - [Module 06 · Serving & Inference](#module-06--serving--inference)
+  - [Module 07 · Performance & Cost Optimization](#module-07--performance--cost-optimization)
+  - [Module 08 · Vector Search](#module-08--vector-search)
+  - [LLMOps & MLE for Leaders](#llmops--mle-for-leaders)
+- [Phase 4 – Governance, Safety & Storytelling](#phase-4--governance-safety--storytelling)
+  - [Module 09 · Security & Safety](#module-09--security--safety)
+  - [Security, Privacy & Compliance](#security-privacy--compliance)
+  - [Module 10 · Governance & Compliance](#module-10--governance--compliance)
+  - [Responsible AI & Governance](#responsible-ai--governance)
+  - [Module 11 · Edge & Embedded](#module-11--edge--embedded)
+  - [Fine-Tuning & Adapters](#fine-tuning--adapters)
+  - [Multimodal](#multimodal)
+  - [Module 12 · Portfolio Patterns](#module-12--portfolio-patterns)
+  - [Architecture Patterns](#architecture-patterns)
+  - [Portfolio & Interview Prep](#portfolio--interview-prep)
+  - [Community & Mentoring](#community--mentoring)
+- [Hands-On Portfolio Track](#hands-on-portfolio-track)
+- [Tooling & Environment Setup](#tooling--environment-setup)
+- [Evaluation & Evals Workflow](#evaluation--evals-workflow)
+- [Responsible AI & Governance Toolkit](#responsible-ai--governance-toolkit)
+- [Project Leadership Playbook](#project-leadership-playbook)
+- [Contributing](#contributing)
+- [FAQ](#faq)
+- [Glossary](#glossary)
+- [What’s Next](#whats-next)
 
-> **Tip:** Keep each demo small but production-minded—add telemetry, track budget, and note trade-offs.
+## How to Use This Repo
+1. **Pick your cadence.** Choose a 4/8/12/24-week plan from the [Learning Path Overview](#learning-path-overview) and block recurring study, build, and retro sessions in your calendar.
+2. **Focus each module.** Select one primary resource from the tables below, skim the rest for context, and write down explicit success metrics before you start building.
+3. **Ship the mini-task.** Complete the mini-task for the module, capture metrics (quality, latency, cost), and link your work back to the module entry in `/curriculum`.
+4. **Reflect and iterate.** After every build, add lessons learned, blockers, and open questions to your experiment log (see `PROJECT_TEMPLATES/EXPERIMENT_LOG.md`).
+5. **Share and lead.** Present your progress weekly to a peer or mentor, practice stakeholder-ready demos, and capture risks/mitigations using the project brief template.
 
-## How to use this roadmap
-1. **Review the module overview.** Skim the curated resources and choose one primary source to study deeply.
-2. **Design a demo.** Pick a real-world problem, scope it to a weekend project, and define success metrics.
-3. **Build and document.** Implement the demo, record latency/cost/quality numbers, and link the repo or notebook in the table above.
-4. **Reflect and iterate.** Write down lessons learned, gaps to fill, and ideas for the next module.
+## Learning Path Overview
+### Milestones
+- **Kickoff:** Confirm prerequisites, install tooling, and publish your personal study plan.
+- **Foundations:** Demonstrate mastery of prompting, embeddings, and lifecycle fundamentals with at least two evaluated demos.
+- **Systems:** Build production-shaped RAG/agent systems with regression tests, telemetry, and cost guardrails.
+- **Scale & Govern:** Operationalize deployments, optimizations, security reviews, and documentation for leadership sign-off.
+- **Lead & Mentor:** Run discovery-to-launch playbooks, mentor contributors, and maintain a portfolio that highlights impact and governance.
 
-— gpt-5-codex
+### Timeline Options
+| Pace | Weekly Commitment | Modules per Week | Expected Outputs |
+|------|-------------------|------------------|------------------|
+| 4-week sprint | 20–25 hrs | 3 | Rapid prototypes, aggressive documentation, leadership brief |
+| 8-week focus | 10–12 hrs | 1–2 | Balanced builds with evaluation suites and risk logs |
+| 12-week steady | 6–8 hrs | 1 | Deep dives with comparison studies and stakeholder decks |
+| 24-week mastery | 3–4 hrs | 0.5 | Slow-and-steady builds with advanced governance artifacts |
+
+### Prerequisites
+- Comfortable with Python, Git, and working in notebooks or VS Code.
+- Basic understanding of cloud services, REST APIs, and command-line tooling.
+- Commitment to capture metrics and write short reflections after every build.
+
+### Outcomes
+- A calibrated study rhythm with an experiment log, risk register, and KPI dashboard.
+- Six to ten portfolio-grade projects covering prompting, RAG, agents, optimization, and governance.
+- Leadership-ready artifacts: project briefs, stakeholder updates, demo scripts, and risk mitigation plans.
+- Confidence to scope, lead, and ship AI-assisted solutions with responsible AI guardrails.
+
+## Phase 0 – Orientation
+### Orientation & Study Plan
+Build the habits of an AI lead before touching code. This section helps you pick a timeline, set weekly rituals, and create an experiment log that keeps you accountable to outcomes rather than hours. You will leave with a personal roadmap, tracking template, and review cadence that mirrors professional AI programs.
+
+**Resource stack**
+
+| Resource | Format | Level | Est. Time (hrs) | Why this resource? |
+| --- | --- | --- | --- | --- |
+| [KAUST Generative AI Training Curriculum](https://github.com/kaust-generative-ai/training-curriculum) | Curriculum | Beginner | 6 | Maps a university-style learning path that you can compress or stretch based on your availability. |
+| [GenAI Curriculum Tracker](https://github.com/nckclrk/generative-ai-curriculum) | Workbook | Beginner | 3 | Supplies checklists and habit trackers for maintaining an experiment log and weekly retros. |
+| [Microsoft Generative AI for Beginners](https://github.com/microsoft/generative-ai-for-beginners) | Course | Beginner | 20 | Offers a canonical syllabus with module outcomes that align to the phases in this repo. |
+
+**Mini-task:** Draft a 12-week plan covering study time, build slots, and reflection windows; commit it to `curriculum/00-introduction/plan.md` and include your success metrics.
+
+<!-- TODO: Extend later
+- Add a printable one-page study planner template.
+- Include recommended retrospective questions for weekly reviews.
+- Capture sample experiment log entries.
+-->
+
+### Module 00 · Introduction
+This module grounds you in the repository structure, tooling expectations, and documentation cadence. You will practice setting up local and cloud environments, using dev containers, and logging your first metrics so future modules are frictionless.
+
+**Resource stack**
+
+| Resource | Format | Level | Est. Time (hrs) | Why this resource? |
+| --- | --- | --- | --- | --- |
+| [fastai fastsetup](https://github.com/fastai/fastsetup) | Setup guide | Beginner | 1 | Walks through dependable Python setup steps on macOS, Linux, and Windows. |
+| [Google Colab Tools](https://github.com/googlecolab/colabtools) | Documentation | Beginner | 1 | Explains how to leverage Colab GPUs, manage secrets, and collaborate quickly. |
+| [dair-ai Machine Learning YouTube Courses](https://github.com/dair-ai/ML-YouTube-Courses) | Playlist index | Beginner | 8 | Provides curated video lessons you can plug into your early study blocks. |
+
+**Mini-task:** Run the `hello-llm.ipynb` notebook (or create your own) that calls a hosted model, records latency, and saves the output plus metric snapshot to your experiment log.
+
+<!-- TODO: Extend later
+- Add screenshots of a configured devcontainer.
+- Provide a secrets-management quick reference.
+- Collect sample experiment log entries from the community.
+-->
+
+## Phase 1 – Foundations
+### Module 01 · GenAI Fundamentals
+Master the core building blocks—tokenization, embeddings, sampling, and LLM lifecycle—so you can reason about trade-offs like an architect. Completing this module means you can explain why a model behaves the way it does, prototype simple prompts, and measure their performance.
+
+**Resource stack**
+
+| Resource | Format | Level | Est. Time (hrs) | Why this resource? |
+| --- | --- | --- | --- | --- |
+| [OpenAI Cookbook](https://github.com/openai/openai-cookbook) | Cookbook | Beginner | 6 | Demonstrates embeddings, chat, and moderation workflows with runnable notebooks. |
+| [Hugging Face Transformers](https://github.com/huggingface/transformers) | Library docs | Intermediate | 10 | Covers model architectures, tokenizer internals, and inference utilities for custom deployments. |
+| [Karpathy LLM101n](https://github.com/karpathy/LLM101n) | Course | Intermediate | 12 | Provides annotated lectures that connect math intuition with working PyTorch code. |
+
+**Mini-task:** Build a notebook that explains an LLM response using log probabilities and token-level analysis; capture insights in your experiment log.
+
+<!-- TODO: Extend later
+- Add a comparison worksheet for open vs. proprietary APIs.
+- Include prompts for explaining transformer internals to stakeholders.
+- Record exemplar metric dashboards for simple Q&A systems.
+-->
+
+### Math for GenAI
+This refresher keeps your mathematical intuition sharp without drowning you in theory. By focusing on the algebra, probability, and optimization concepts you actively use in prompting, embedding search, and fine-tuning, you can reason about quality metrics and optimization levers like a lead engineer.
+
+**Resource stack**
+
+| Resource | Format | Level | Est. Time (hrs) | Why this resource? |
+| --- | --- | --- | --- | --- |
+| [nn-zero-to-hero](https://github.com/karpathy/nn-zero-to-hero) | Course | Beginner | 10 | Revives calculus and optimization intuition using code-first lectures. |
+| [Numerical Linear Algebra](https://github.com/fastai/numerical-linear-algebra) | Book | Intermediate | 12 | Focuses on matrix decompositions and vector spaces essential for embeddings and attention. |
+| [Math for ML](https://github.com/cadizm/math-for-ml) | Notes | Beginner | 5 | Condenses probability and vector math essentials into quick-reference notes. |
+
+**Mini-task:** Create a one-page cheat sheet summarizing cosine similarity, softmax, and cross-entropy; add it to `/curriculum/01-genai-fundamentals/notes.md`.
+
+<!-- TODO: Extend later
+- Add practice problems tied to upcoming modules.
+- Capture visual aids for explaining optimization steps to non-technical stakeholders.
+-->
+
+### Module 02 · Prompting & Structured Outputs
+Build prompts that produce reliable, schema-compliant outputs and understand how to evaluate them. This module prepares you to hand off prompts to production teams with confidence and to debug failures quickly.
+
+**Resource stack**
+
+| Resource | Format | Level | Est. Time (hrs) | Why this resource? |
+| --- | --- | --- | --- | --- |
+| [Prompt Engineering Guide](https://github.com/dair-ai/Prompt-Engineering-Guide) | Guide | Intermediate | 6 | Shares tested prompt blueprints, safety considerations, and evaluation tips. |
+| [Awesome Prompt Engineering](https://github.com/promptslab/Awesome-Prompt-Engineering) | Repository | Intermediate | 4 | Aggregates tools and research that improve structured outputs and validation. |
+| [Outlines](https://github.com/outlines-dev/outlines) | Library | Intermediate | 3 | Provides deterministic prompting primitives (regex, JSON, CFG) to enforce schema fidelity. |
+
+**Mini-task:** Build a prompt pipeline that extracts structured JSON from support emails, validates the schema with `pydantic`, and logs failure cases.
+
+<!-- TODO: Extend later
+- Add a gallery of structured output validation strategies.
+- Collect examples of schema drift and remediation steps.
+- Include evaluation prompts for hallucination checks.
+-->
+
+### Prompt Engineering Essentials
+Treat prompting as software engineering—versioned, tested, and safe. This section shows you how to create reproducible prompting workflows, integrate evaluation loops, and reason about safety constraints like an AI lead.
+
+**Resource stack**
+
+| Resource | Format | Level | Est. Time (hrs) | Why this resource? |
+| --- | --- | --- | --- | --- |
+| [Google Cloud Generative AI Examples](https://github.com/GoogleCloudPlatform/generative-ai) | Examples | Beginner | 5 | Demonstrates role/task/format prompting patterns across enterprise-grade APIs. |
+| [Anthropic Cookbook](https://github.com/anthropics/anthropic-cookbook) | Cookbook | Intermediate | 6 | Shows Claude function calling, safety settings, and evaluation harnesses. |
+| [Microsoft Promptflow](https://github.com/microsoft/promptflow) | Framework | Intermediate | 5 | Enables reproducible prompt pipelines with versioned data and automated tests. |
+
+**Mini-task:** Configure a promptflow project (or equivalent) that runs regression tests on three prompts and posts results to your experiment log.
+
+<!-- TODO: Extend later
+- Add deployment-ready CI pipelines for prompt regression.
+- Collect examples of safety testing scripts.
+- Document recommended prompt versioning practices.
+-->
+
+## Phase 2 – Orchestration & Knowledge Systems
+### Module 03 · Agents & Orchestration
+Move from single prompts to multi-step workflows. You will design tool schemas, permission models, and traceability so that your agents can operate safely and predictably in production contexts.
+
+**Resource stack**
+
+| Resource | Format | Level | Est. Time (hrs) | Why this resource? |
+| --- | --- | --- | --- | --- |
+| [LangGraph](https://github.com/langchain-ai/langgraph) | Framework | Intermediate | 5 | Introduces graph-based agent orchestration with built-in guardrails. |
+| [Marvin](https://github.com/PrefectHQ/marvin) | Framework | Intermediate | 4 | Demonstrates pragmatic task orchestration with Prefect observability. |
+| [Semantic Kernel](https://github.com/microsoft/semantic-kernel) | SDK | Intermediate | 6 | Combines planning, connectors, and memory for enterprise-ready agents. |
+
+**Mini-task:** Build a two-tool agent (web search + summarizer) that logs every tool call, outcome, and cost to LangGraph or Prefect and produces a short stakeholder update.
+
+<!-- TODO: Extend later
+- Capture sample RACI charts for agent tool permissions.
+- Add reusable guardrail snippets for agent retries.
+- Include telemetry dashboards for tracing agent behavior.
+-->
+
+### Agents & Tool-Use
+Focus on designing deterministic tool contracts, safety guardrails, and human-in-the-loop controls. This section equips you to argue for or against tool integrations and to manage risk like an AI program lead.
+
+**Resource stack**
+
+| Resource | Format | Level | Est. Time (hrs) | Why this resource? |
+| --- | --- | --- | --- | --- |
+| [AutoGen](https://github.com/microsoft/autogen) | Framework | Advanced | 8 | Explores multi-agent collaboration, human-in-the-loop flows, and tool routing. |
+| [Langroid](https://github.com/langroid/langroid) | Framework | Advanced | 6 | Emphasizes deterministic tool contracts and streaming trace analysis. |
+| [Tool Calling Guide](https://github.com/ALucek/tool-calling-guide) | Guide | Intermediate | 2 | Summarizes schema design and safety considerations for external tool invocation. |
+
+**Mini-task:** Document a tool registry (YAML or JSON) describing inputs, outputs, rate limits, and safety checks for three tools; review it with a peer.
+
+<!-- TODO: Extend later
+- Provide sample SOC2-ready tool documentation.
+- Add escalation flows for tool failure scenarios.
+-->
+
+### Module 04 · RAG Essentials
+Bring proprietary knowledge into your LLM stack. You will learn how to ingest, chunk, embed, and evaluate knowledge bases while capturing the metrics leaders need to green-light deployments.
+
+**Resource stack**
+
+| Resource | Format | Level | Est. Time (hrs) | Why this resource? |
+| --- | --- | --- | --- | --- |
+| [LlamaIndex](https://github.com/jerryjliu/llama_index) | Framework | Intermediate | 6 | Covers ingestion, retrieval, and evaluation building blocks with modular components. |
+| [Pinecone Examples](https://github.com/pinecone-io/examples) | Examples | Intermediate | 4 | Demonstrates hybrid search, metadata filtering, and streaming ingestion. |
+| [Haystack](https://github.com/deepset-ai/haystack) | Framework | Intermediate | 6 | Provides production-grade pipelines for retrievers, generators, and evaluators. |
+
+**Mini-task:** Implement a small RAG service over a folder of internal docs; log Recall@k, latency, and cost per query.
+
+<!-- TODO: Extend later
+- Add guidance on cold-start knowledge ingestion.
+- Share scripts for incremental indexing and cache invalidation.
+- Capture templates for RAG service runbooks.
+-->
+
+### Retrieval-Augmented Generation
+Go beyond baseline RAG with graph-based memory, reranking, and cost-sensitive optimization. This section positions you to lead architectural decisions for large knowledge systems.
+
+**Resource stack**
+
+| Resource | Format | Level | Est. Time (hrs) | Why this resource? |
+| --- | --- | --- | --- | --- |
+| [GraphRAG](https://github.com/microsoft/graphrag) | Toolkit | Advanced | 6 | Shows how to capture relationships and entity graphs for richer retrieval. |
+| [fastRAG](https://github.com/IntelLabs/fastRAG) | Toolkit | Advanced | 5 | Benchmarks latency and quality trade-offs across RAG configurations. |
+| [Awesome GraphRAG](https://github.com/DEEP-PolyU/Awesome-GraphRAG) | Curated list | Advanced | 3 | Aggregates research and tooling for graph-enhanced retrieval systems. |
+
+**Mini-task:** Compare baseline and graph-enhanced RAG on one dataset; document cost, latency, and quality deltas in your experiment log.
+
+<!-- TODO: Extend later
+- Add templates for presenting RAG trade-off decisions to leadership.
+- Collect latency budgeting worksheets for RAG stacks.
+-->
+
+### Module 05 · Evaluation & Observability
+Make quality measurable and regression-proof. This module ensures you can design golden datasets, run automated checks, and communicate evaluation results to stakeholders.
+
+**Resource stack**
+
+| Resource | Format | Level | Est. Time (hrs) | Why this resource? |
+| --- | --- | --- | --- | --- |
+| [Ragas](https://github.com/explodinggradients/ragas) | Library | Intermediate | 4 | Implements retrieval and answer quality metrics for RAG pipelines. |
+| [promptfoo](https://github.com/promptfoo/promptfoo) | CLI | Intermediate | 3 | Automates prompt regression tests with diff-friendly outputs. |
+| [Langfuse](https://github.com/langfuse/langfuse) | Platform | Intermediate | 5 | Provides tracing, analytics, and feedback dashboards. |
+| [TruLens](https://github.com/truera/trulens) | Framework | Intermediate | 4 | Adds evaluator suites, guardrails, and audit trails for LLM outputs. |
+
+**Mini-task:** Add an automated evaluation step to one of your projects (RAG or agent) using Ragas or promptfoo, and publish the results to a shared dashboard or README.
+
+<!-- TODO: Extend later
+- Add sample evaluation rubrics for stakeholders.
+- Provide automation examples for nightly regression suites.
+- Collect case studies on evaluation-driven rollbacks.
+-->
+
+### Evaluation & Evals
+Deepen your evaluation practice with research-grade benchmarks and harnesses. This section prepares you to justify evaluation choices to leadership and compliance teams.
+
+**Resource stack**
+
+| Resource | Format | Level | Est. Time (hrs) | Why this resource? |
+| --- | --- | --- | --- | --- |
+| [InstructEval](https://github.com/declare-lab/instruct-eval) | Benchmark | Advanced | 4 | Supplies task-specific datasets for instruction tuning and evaluation. |
+| [BigCode Evaluation Harness](https://github.com/bigcode-project/bigcode-evaluation-harness) | Benchmark | Advanced | 6 | Standardizes code generation metrics, baselines, and prompts. |
+| [HELM](https://github.com/stanford-crfm/helm) | Benchmark | Advanced | 8 | Offers comprehensive evaluation across accuracy, safety, and efficiency dimensions. |
+
+**Mini-task:** Design a lightweight evaluation charter summarizing metrics, datasets, and acceptance thresholds for a project; review it with a peer lead.
+
+<!-- TODO: Extend later
+- Publish sample evaluation charters for different project types.
+- Capture guidance on using LLM-as-a-judge responsibly.
+-->
+
+## Phase 3 – Deployment & Optimization
+### Module 06 · Serving & Inference
+Operate models reliably under production constraints. You will weigh managed vs. self-hosted deployments, implement batching and streaming, and design service-level objectives for AI endpoints.
+
+**Resource stack**
+
+| Resource | Format | Level | Est. Time (hrs) | Why this resource? |
+| --- | --- | --- | --- | --- |
+| [vLLM](https://github.com/vllm-project/vllm) | Inference engine | Intermediate | 5 | Covers paged KV cache serving with OpenAI-compatible APIs. |
+| [Text Generation Inference](https://github.com/huggingface/text-generation-inference) | Inference server | Intermediate | 5 | Demonstrates scalable serving with token streaming and scaling knobs. |
+| [TensorRT-LLM](https://github.com/NVIDIA/TensorRT-LLM) | Toolkit | Advanced | 6 | Provides GPU-optimized pipelines, quantization, and multi-GPU orchestration. |
+
+**Mini-task:** Deploy a small open model using vLLM or TGI, expose an OpenAI-compatible endpoint, and capture latency, throughput, and cost metrics.
+
+<!-- TODO: Extend later
+- Add Helm charts or Terraform snippets for automated deployments.
+- Document blue/green deployment workflows for model updates.
+- Collect service-level objective templates.
+-->
+
+### Module 07 · Performance & Cost Optimization
+Learn how to tune latency, throughput, and cost without sacrificing quality. This module makes you comfortable with quantization, caching, speculative decoding, and routing strategies.
+
+**Resource stack**
+
+| Resource | Format | Level | Est. Time (hrs) | Why this resource? |
+| --- | --- | --- | --- | --- |
+| [LLM-AWQ](https://github.com/mit-han-lab/llm-awq) | Library | Advanced | 4 | Explains activation-aware quantization with reproducible benchmarks. |
+| [LLM Perf Bench](https://github.com/mlc-ai/llm-perf-bench) | Benchmark | Advanced | 5 | Provides scripts to profile latency, throughput, and memory usage. |
+| [lit-gpt](https://github.com/Lightning-AI/litgpt) | Framework | Intermediate | 6 | Combines quantization, LoRA, and optimized serving recipes. |
+
+**Mini-task:** Run a performance benchmark comparing baseline vs. quantized or cached inference; document the deltas and decision criteria in your experiment log.
+
+<!-- TODO: Extend later
+- Add capacity planning worksheets.
+- Provide templates for cost-per-task dashboards.
+-->
+
+### Module 08 · Vector Search
+Choose and tune the right vector database for your workload. You will compare FAISS, pgvector, and Milvus across quality, latency, and operational complexity.
+
+**Resource stack**
+
+| Resource | Format | Level | Est. Time (hrs) | Why this resource? |
+| --- | --- | --- | --- | --- |
+| [FAISS](https://github.com/facebookresearch/faiss) | Library | Intermediate | 6 | Explains exact vs. approximate indices and GPU acceleration. |
+| [pgvector](https://github.com/pgvector/pgvector) | Extension | Intermediate | 4 | Shows how to embed vector search directly in PostgreSQL. |
+| [Milvus](https://github.com/milvus-io/milvus) | Vector database | Intermediate | 6 | Delivers a distributed vector database with hybrid search and scaling. |
+
+**Mini-task:** Swap the vector store in your RAG project (e.g., FAISS → pgvector) and compare Recall@k and latency over a golden dataset.
+
+<!-- TODO: Extend later
+- Capture operational checklists for vector store upgrades.
+- Add cost comparisons across managed vs. self-hosted options.
+-->
+
+### LLMOps & MLE for Leaders
+Structure your operations like a modern AI platform team. You will implement observability, rollout/rollback strategies, governance checklists, and stakeholder communications.
+
+**Resource stack**
+
+| Resource | Format | Level | Est. Time (hrs) | Why this resource? |
+| --- | --- | --- | --- | --- |
+| [Awesome LLMOps](https://github.com/tensorchord/Awesome-LLMOps) | Curated list | Intermediate | 6 | Maps the LLMOps ecosystem for monitoring, deployment, and governance. |
+| [LLM Engineer's Handbook](https://github.com/PacktPublishing/LLM-Engineers-Handbook) | Book code | Intermediate | 10 | Provides templates for project management, deployment, and stakeholder updates. |
+| [OpenLLMetry](https://github.com/traceloop/openllmetry) | Toolkit | Advanced | 5 | Shows how to instrument LLM apps with OpenTelemetry standards. |
+
+**Mini-task:** Instrument one of your services with OpenLLMetry (or equivalent), add latency and cost alerts, and draft a rollback checklist.
+
+<!-- TODO: Extend later
+- Publish sample incident response runbooks.
+- Add ROI calculators for LLM features.
+-->
+
+## Phase 4 – Governance, Safety & Storytelling
+### Module 09 · Security & Safety
+Protect users, data, and systems from LLM-specific threats. You will build guardrails, red-team playbooks, and escalation paths that satisfy security reviews.
+
+**Resource stack**
+
+| Resource | Format | Level | Est. Time (hrs) | Why this resource? |
+| --- | --- | --- | --- | --- |
+| [OWASP Top 10 for LLM Applications](https://github.com/OWASP/www-project-top-10-for-large-language-model-applications) | Guide | Intermediate | 3 | Lists top attack vectors and mitigation strategies for LLM apps. |
+| [NeMo Guardrails](https://github.com/NVIDIA/NeMo-Guardrails) | Framework | Intermediate | 5 | Implements policy-based guardrails for chat, RAG, and tool agents. |
+| [Rebuff](https://github.com/protectai/rebuff) | Toolkit | Intermediate | 4 | Detects prompt injection attempts and provides sandboxed tool execution. |
+
+**Mini-task:** Conduct a mini red-team on one of your demos using OWASP guidance; document findings, mitigations, and residual risks.
+
+<!-- TODO: Extend later
+- Add a prompt-injection replay library.
+- Provide templates for security review summaries.
+-->
+
+### Security, Privacy & Compliance
+Ensure your systems respect privacy laws and data handling policies. This section equips you with checklists, toolkits, and automated checks that compliance teams expect.
+
+**Resource stack**
+
+| Resource | Format | Level | Est. Time (hrs) | Why this resource? |
+| --- | --- | --- | --- | --- |
+| [AI Privacy Checklist](https://github.com/JariPesonen/AIPrivacyChecklist) | Checklist | Intermediate | 2 | Provides privacy impact questions to ask before shipping AI features. |
+| [AI Privacy Toolkit](https://github.com/IBM/ai-privacy-toolkit) | Toolkit | Advanced | 5 | Offers differential privacy utilities and policy templates. |
+| [AI Compliance Auditor](https://github.com/awsdataarchitect/ai-compliance-auditor) | Toolkit | Intermediate | 4 | Demonstrates automated compliance checks for data retention and access controls. |
+
+**Mini-task:** Complete a privacy impact assessment for an existing project using the checklist; log findings and remediation actions in your risk tracker.
+
+<!-- TODO: Extend later
+- Add DPIA templates aligned with regional regulations.
+- Provide examples of redacted logging strategies.
+-->
+
+### Module 10 · Governance & Compliance
+Learn the language of policy and governance so you can brief legal, risk, and executive stakeholders. You will create model cards, lineage documentation, and go/no-go criteria.
+
+**Resource stack**
+
+| Resource | Format | Level | Est. Time (hrs) | Why this resource? |
+| --- | --- | --- | --- | --- |
+| [EU AI Act Notes](https://github.com/daveshap/EU_AI_Act) | Notes | Intermediate | 4 | Summarizes obligations by risk class with digestible tables. |
+| [AI Governance Playbook](https://github.com/Neetu-kapoor/Ai-governance-playbook) | Playbook | Intermediate | 3 | Provides governance charters, RACI templates, and stakeholder maps. |
+| [AI Governance Risk & Compliance Docs](https://github.com/ahsan-141117/AI-Governance-Risk-Compliance-Documentation) | Templates | Intermediate | 3 | Offers audit-ready checklists and policy samples tailored to AI programs. |
+
+**Mini-task:** Produce a one-page governance brief summarizing purpose, risk class, mitigations, and open questions for one of your demos.
+
+<!-- TODO: Extend later
+- Collect example governance briefs from industry case studies.
+- Add sign-off checklist templates for launch committees.
+-->
+
+### Responsible AI & Governance
+Operationalize ethics, fairness, and transparency. Use this section to create cross-functional processes, interpretability reports, and continuous monitoring plans.
+
+**Resource stack**
+
+| Resource | Format | Level | Est. Time (hrs) | Why this resource? |
+| --- | --- | --- | --- | --- |
+| [Awesome Responsible AI](https://github.com/AthenaCore/AwesomeResponsibleAI) | Curated list | Intermediate | 6 | Aggregates research, tooling, and best practices across responsible AI domains. |
+| [Responsible AI Toolbox](https://github.com/microsoft/responsible-ai-toolbox) | Toolkit | Intermediate | 6 | Provides interpretability, fairness, and error analysis dashboards. |
+| [Awesome ML Model Governance](https://github.com/visenger/Awesome-ML-Model-Governance) | Curated list | Intermediate | 4 | Offers frameworks for lifecycle governance and audit readiness. |
+
+**Mini-task:** Run a bias or fairness analysis on one project using the Responsible AI Toolbox; summarize key findings and mitigations.
+
+<!-- TODO: Extend later
+- Add a model card template for this repository.
+- Provide case studies on responsible AI escalations.
+-->
+
+### Module 11 · Edge & Embedded
+Deploy small language models on constrained hardware. You will learn compression, telemetry, and offline testing strategies for edge deployments.
+
+**Resource stack**
+
+| Resource | Format | Level | Est. Time (hrs) | Why this resource? |
+| --- | --- | --- | --- | --- |
+| [Edge AI for Beginners](https://github.com/microsoft/edgeai-for-beginners) | Course | Intermediate | 10 | Explains hardware-aware deployment and telemetry collection. |
+| [ONNX Runtime GenAI](https://github.com/microsoft/onnxruntime-genai) | Toolkit | Intermediate | 5 | Runs quantized models across CPU, GPU, and mobile. |
+| [Phi-3 Mini Samples](https://github.com/Azure-Samples/Phi-3MiniSamples) | Examples | Intermediate | 4 | Demonstrates on-device SLM workflows with telemetry capture. |
+
+**Mini-task:** Deploy a small model (Phi-3 mini or similar) on an edge device or emulator, recording latency, memory, and temperature metrics.
+
+<!-- TODO: Extend later
+- Document hardware compatibility matrices.
+- Add battery impact measurement guidelines.
+-->
+
+### Fine-Tuning & Adapters
+Upgrade models with efficient fine-tuning strategies. You will compare PEFT methods, understand data curation, and build evaluation pipelines that justify fine-tune investments.
+
+**Resource stack**
+
+| Resource | Format | Level | Est. Time (hrs) | Why this resource? |
+| --- | --- | --- | --- | --- |
+| [PEFT](https://github.com/huggingface/peft) | Library | Intermediate | 5 | Implements LoRA, QLoRA, and other adapter techniques. |
+| [QLoRA](https://github.com/artidoro/qlora) | Toolkit | Advanced | 6 | Explains low-bit fine-tuning with reproducible scripts. |
+| [Open Instruct](https://github.com/allenai/open-instruct) | Dataset & recipes | Advanced | 8 | Provides data pipelines and evaluation baselines for supervised fine-tuning. |
+
+**Mini-task:** Fine-tune (or simulate fine-tuning with PEFT) on a small dataset and log before/after evaluation metrics and cost.
+
+<!-- TODO: Extend later
+- Add guardrails for dataset curation and labeling.
+- Include RLHF resource suggestions.
+-->
+
+### Multimodal
+Combine text, vision, and audio capabilities to build richer experiences. You will evaluate multimodal models and plan for data pipelines that handle diverse inputs.
+
+**Resource stack**
+
+| Resource | Format | Level | Est. Time (hrs) | Why this resource? |
+| --- | --- | --- | --- | --- |
+| [LLaVA](https://github.com/haotian-liu/LLaVA) | Model | Advanced | 6 | Shows visual instruction tuning and evaluation. |
+| [Segment Anything](https://github.com/facebookresearch/segment-anything) | Model | Intermediate | 5 | Provides segmentation tools for visual reasoning. |
+| [Whisper](https://github.com/openai/whisper) | Model | Intermediate | 4 | Enables audio transcription and integration into multimodal agents. |
+
+**Mini-task:** Build a simple multimodal demo (e.g., describe image + summarize transcript) and measure latency across modalities.
+
+<!-- TODO: Extend later
+- Add dataset sourcing guidance for multimodal tasks.
+- Document privacy considerations for audio/video inputs.
+-->
+
+### Module 12 · Portfolio Patterns
+Craft demos and artifacts that resonate with hiring managers and stakeholders. You will package outcomes, metrics, and lessons learned into compelling narratives.
+
+**Resource stack**
+
+| Resource | Format | Level | Est. Time (hrs) | Why this resource? |
+| --- | --- | --- | --- | --- |
+| [GenAI Projects Portfolio](https://github.com/Ashleshk/GenAI-Projects-Portfolio) | Examples | Beginner | 3 | Shows how to present project metrics and narratives clearly. |
+| [SAP BTP GenAI Starter Kit](https://github.com/SAP-samples/btp-genai-starter-kit) | Starter kit | Intermediate | 6 | Provides production-shaped scaffolds and architecture diagrams. |
+| [AWS Agentic AI Demos](https://github.com/aws-samples/sample-agentic-ai-demos) | Examples | Intermediate | 5 | Offers multi-agent demos with KPIs and deployment scripts. |
+
+**Mini-task:** Publish one polished project page with problem statement, architecture diagram, metrics, and leadership summary; link it in `curriculum/12-portfolio-patterns`.
+
+<!-- TODO: Extend later
+- Add storytelling frameworks for portfolio presentations.
+- Collect exemplar slide decks or demo videos.
+-->
+
+### Architecture Patterns
+Compare architectural strategies for GenAI solutions so you can pick the right approach for the problem, budget, and risk profile.
+
+```mermaid
+graph TD
+    P[Prompt-only] -->|Fast setup| U[Use cases: FAQs, brainstorming]
+    R[RAG-first] -->|Knowledge heavy| K[Use cases: support copilots]
+    F[Fine-tune-first] -->|Domain specialization| D[Use cases: tone, compliance]
+    H[Hybrid] -->|Best of all| X[Use cases: mission-critical copilots]
+```
+
+**Resource stack**
+
+| Resource | Format | Level | Est. Time (hrs) | Why this resource? |
+| --- | --- | --- | --- | --- |
+| [Modular RAG](https://github.com/ThomasVitale/modular-rag) | Guide | Intermediate | 4 | Breaks RAG systems into reusable modules and deployment patterns. |
+| [LLM Multi-Agent Patterns](https://github.com/VinZCodz/llm_multi_agent_patterns) | Guide | Advanced | 4 | Explains planner/worker, critique, and reflection loops with diagrams. |
+| [Kernel Memory](https://github.com/microsoft/kernel-memory) | Framework | Intermediate | 5 | Demonstrates memory-first architectures with ingestion, chunking, and retrieval services. |
+
+**Mini-task:** For an existing project, map your architecture to one of the patterns above, note trade-offs, and propose a next iteration.
+
+<!-- TODO: Extend later
+- Add cost modeling templates for each pattern.
+- Include real-world case studies with metrics.
+-->
+
+### Portfolio & Interview Prep
+Translate your technical work into leadership-ready stories. This section helps you prep behavioral narratives, system design answers, and take-home strategies.
+
+**Resource stack**
+
+| Resource | Format | Level | Est. Time (hrs) | Why this resource? |
+| --- | --- | --- | --- | --- |
+| [GenAI Interview Questions](https://github.com/a-tabaza/genai_interview_questions) | Question bank | Intermediate | 4 | Highlights current GenAI system design and scenario prompts. |
+| [MLE/DS Interview Prep Guide](https://github.com/whaleonearth/MLE-DS-Interview-Prep-Guide) | Guide | Intermediate | 6 | Provides behavioral prompts, take-home advice, and technical refreshers. |
+| [Andreis Interview Handbook](https://github.com/andreis/interview) | Guide | Intermediate | 8 | Supplies structured preparation checklists and storytelling frameworks. |
+
+**Mini-task:** Draft three STAR-format stories (shipping impact, risk mitigation, mentorship) and rehearse them aloud.
+
+<!-- TODO: Extend later
+- Add mock interview scripts focused on AI leadership scenarios.
+- Provide template slides for stakeholder demos.
+-->
+
+### Community & Mentoring
+Build the support system that keeps you growing. You will learn how to run study groups, mentor others, and contribute back to the ecosystem.
+
+**Resource stack**
+
+| Resource | Format | Level | Est. Time (hrs) | Why this resource? |
+| --- | --- | --- | --- | --- |
+| [Mentorship Guide Docs](https://github.com/mentorship-sponsorship/mentorship-guide-docs) | Guide | Beginner | 2 | Explains mentorship agreements, feedback loops, and expectations. |
+| [The Open Source Way Guidebook](https://github.com/theopensourceway/guidebook) | Guidebook | Intermediate | 6 | Details how to cultivate communities of practice with transparent governance. |
+| [Papers We Love](https://github.com/papers-we-love/papers-we-love) | Community | Intermediate | 6 | Provides a model for study groups with ready-made reading lists and facilitation tips. |
+
+**Mini-task:** Host or join a one-hour study group session, capture key takeaways, and log new questions or resources discovered.
+
+<!-- TODO: Extend later
+- Add guidelines for running mentorship circles.
+- Collect examples of community charters.
+-->
+
+## Hands-On Portfolio Track
+Progress through these projects to demonstrate breadth and leadership. Each project includes a problem statement, acceptance criteria, deliverables, and a stretch goal for leveling up.
+
+| # | Project | Problem Statement | Acceptance Criteria | Deliverables | Stretch Goal |
+|---|---|---|---|---|---|
+| 1 | Prompt Diagnostics Notebook | Investigate why a prompt underperforms across different inputs. | Document at least three failure modes with evidence and proposed fixes. | Notebook + metric screenshots + written recap. | Add automated regression tests via promptfoo. |
+| 2 | Retrieval QA Service | Turn a document corpus into a reliable Q&A endpoint. | ≥0.7 Recall@5, latency <2s, cost per query logged. | API, evaluation report, architecture diagram. | Implement hybrid retrieval and compare to baseline. |
+| 3 | Agentic Research Copilot | Build an agent that researches and drafts summaries. | Tool permissions enforced, every action traced, cost budget adhered to. | Demo video, trace logs, stakeholder briefing note. | Add human-in-the-loop approval workflow. |
+| 4 | Evaluation Dashboard | Centralize evaluation metrics for an existing project. | Golden dataset tracked, automated nightly runs, alerting configured. | Dashboard screenshots, evaluation charter, post-mortem template. | Integrate OpenTelemetry traces and cost alerts. |
+| 5 | Optimized Serving Stack | Deploy and optimize a model with KV cache and quantization. | Latency reduced ≥30% vs. baseline while keeping quality stable. | Deployment scripts, benchmark report, rollback plan. | Add autoscaling policy and chaos test results. |
+| 6 | Responsible AI Review | Conduct a fairness/privacy assessment on a shipped project. | Risks identified, mitigations proposed, governance sign-off simulated. | Model card, risk register update, stakeholder deck. | Run a live red-team session with documented outcomes. |
+| 7 | Multimodal Insight Tool | Combine image and audio understanding in a single experience. | Handles batch input, logs cross-modal latency, passes safety filters. | Notebook/app, telemetry summary, user guide. | Deploy to an edge environment with offline fallback. |
+| 8 | Portfolio Narrative | Synthesize your work for executives or hiring managers. | Includes problem, metrics, ROI, risk management, and next steps. | Slide deck, narrated video, README entry. | Record a mock stakeholder meeting and collect feedback. |
+
+Log each project in `curriculum/12-portfolio-patterns` and link to live demos or repositories whenever possible.
+
+## Tooling & Environment Setup
+1. **Local Python environment**
+   - Install [Miniforge](https://github.com/conda-forge/miniforge) and create a conda environment per module (`conda create -n genai python=3.11`).
+   - Pin dependencies with `pip-tools` or `uv` and record versions in `requirements.lock`.
+2. **Development containers**
+   - Use the [VS Code Dev Containers templates](https://github.com/microsoft/vscode-dev-containers) to standardize tooling (Python, Node, CUDA) across contributors.
+   - Mount your experiment logs and secrets via `.devcontainer/devcontainer.json` to avoid committing sensitive data.
+3. **GPU access**
+   - For ad-hoc experiments, spin up Colab Pro/Kaggle notebooks; for repeatable workloads, use [runpodctl](https://github.com/runpod/runpodctl) or similar to manage on-demand GPU pods.
+   - Capture GPU specs, cost per hour, and usage notes in your experiment log.
+4. **Secrets management**
+   - Store API keys in `.env` files loaded via `python-dotenv` or use a secret manager (AWS Secrets Manager, Azure Key Vault).
+   - Never commit secrets; add `.env` to `.gitignore` and document rotation cadence in the project brief.
+5. **Telemetry & monitoring**
+   - Standardize logging format (JSON) and include request ID, prompt hash, latency, and cost for every call.
+   - Forward logs to an observability stack (OpenLLMetry, Langfuse, Grafana) and set alert thresholds early.
+
+## Evaluation & Evals Workflow
+Follow this checklist for every experiment:
+1. **Define success upfront.** Capture metrics, guardrails, and sample prompts in the project brief before you write code.
+2. **Build a golden dataset.** Start with 10–20 curated cases that represent core use-cases and edge cases; expand as you discover failures.
+3. **Automate regressions.** Use promptfoo, Ragas, or HELM harnesses to run regression suites after every change; store results alongside code.
+4. **Capture human feedback.** Add lightweight review forms or rubric-based scoring so stakeholders can weigh in on quality trade-offs.
+5. **Report transparently.** Summarize results in plain language: metric deltas, known limitations, risks, and recommended next steps.
+6. **Gate releases.** Tie deployment decisions to evaluation thresholds and document go/no-go outcomes in the governance brief.
+
+## Responsible AI & Governance Toolkit
+- **Model cards:** Use `PROJECT_TEMPLATES/MODEL_CARD.md` to document intended use, data sources, and ethical considerations.
+- **Risk registers:** Maintain a living list of risks, mitigations, and owners in your project brief; review during weekly stand-ups.
+- **Policy alignment:** Map every project to the relevant standards (EU AI Act class, company policies) and record compliance artifacts.
+- **Incident response:** Draft playbooks for escalation (contacts, triggers, containment steps) and rehearse them quarterly.
+- **Stakeholder updates:** Provide monthly governance reports summarizing KPIs, incidents, and roadmap changes.
+
+## Project Leadership Playbook
+| Phase | Objectives | Key Artifacts | Cadence |
+| --- | --- | --- | --- |
+| Discovery | Clarify problem, users, success metrics, constraints. | Project brief, stakeholder map, risk log seed. | 1–2 weeks |
+| Scoping | Design architecture, evaluation plan, resourcing. | Architecture diagram, evaluation charter, RACI. | 1 week |
+| Delivery | Build, evaluate, iterate, document. | Experiment logs, metric dashboards, demo scripts. | Weekly sprints |
+| Launch | Harden, run security/privacy reviews, communicate. | Launch checklist, governance sign-off, runbook. | 1–2 weeks |
+| MLE/LLMOps | Monitor, optimize, retrain, and scale. | Observability dashboards, cost reports, model card updates. | Ongoing |
+
+**RACI Tips:**
+- Product/Business owners = Accountable for outcomes.
+- Tech lead/AI lead = Responsible for build and evaluation.
+- Security, Legal, Compliance = Consulted before launch.
+- Support, Enablement, Community = Informed on updates and changes.
+
+**Stakeholder communication:**
+- Weekly async update (metrics, risks, decisions).
+- Bi-weekly live demo with Q&A.
+- Monthly governance review (compliance, incidents, roadmap changes).
+
+## Contributing
+We welcome curated resources, new learning modules, and community-sourced experiments. Please read [CONTRIBUTING.md](CONTRIBUTING.md) for style rules, the resource quality bar, and the pull request checklist. By participating, you agree to follow the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## FAQ
+1. **How much math do I really need?** Enough to reason about embeddings, similarity metrics, and optimization. The [Math for GenAI](#math-for-genai) section highlights the essentials without diving into unused theory.
+2. **Can I skip to advanced modules?** Yes—use the timeline table to choose a fast track, but complete the mini-tasks you skip retrospectively to ensure coverage.
+3. **Where do I log experiments?** Use the templates in `PROJECT_TEMPLATES/` and link entries from each module directory.
+4. **How do I pick models?** Start with hosted APIs for speed, move to open weights when you need control, and document trade-offs in your experiment log.
+5. **What if I don’t have a GPU?** Use Colab/Kaggle for prototypes, or rent hourly GPUs with runpodctl/Modal. Many modules focus on hosted APIs so you can still progress.
+6. **How do I measure success?** Combine task metrics (accuracy, latency, cost) with stakeholder feedback and business impact; record them in the governance brief.
+7. **How should I document risks?** Use the project brief template to capture risks, mitigations, owners, and review cadence.
+8. **Can I use paid resources?** Yes, but flag them clearly in the resource tables and offer a free alternative when possible.
+9. **How do I practice leadership?** Run weekly demos, document decisions, mentor peers, and volunteer to facilitate study groups.
+10. **What if a resource becomes outdated?** Submit an issue or PR referencing the Maintenance Plan; we retire or replace resources quarterly.
+
+## Glossary
+| Term | Definition |
+| --- | --- |
+| Alignment | Techniques to make models adhere to human values and instructions. |
+| Attention | Mechanism that lets models weigh different parts of the input sequence when generating outputs. |
+| Auto-regressive decoding | Generating text token-by-token, conditioning on previously generated tokens. |
+| Benchmark | Standardized dataset and metric for comparing model performance. |
+| Chain-of-thought | Prompting strategy encouraging models to reason step-by-step. |
+| Embedding | Dense vector representation capturing semantic meaning of text or other modalities. |
+| Evaluation charter | Document describing metrics, datasets, and thresholds for a project. |
+| Fine-tuning | Further training a model on domain-specific data to improve performance. |
+| Guardrails | Rules or systems that constrain model behavior to safe, expected outputs. |
+| Hallucination | Confident but incorrect model output not grounded in source data. |
+| Hybrid search | Combining lexical (keyword) and vector similarity search for retrieval. |
+| KV cache | Key-value cache used to speed up transformer inference by reusing attention states. |
+| LoRA | Low-Rank Adaptation technique for parameter-efficient fine-tuning. |
+| Model card | Transparent document describing model purpose, data, metrics, and limitations. |
+| Observation | Logged event capturing prompt, response, latency, and cost for analysis. |
+| Prompt injection | Attack where malicious input alters the model’s instructions or behavior. |
+| RACI | Responsibility matrix defining who is Responsible, Accountable, Consulted, Informed. |
+| RAG | Retrieval-Augmented Generation, combining retrieval with generation for grounded answers. |
+| Regression suite | Automated tests ensuring new changes don’t break previous behavior. |
+| Risk register | Living document tracking project risks, impact, likelihood, and mitigations. |
+| Safety review | Formal assessment covering security, privacy, and responsible AI considerations. |
+| Speculative decoding | Technique that uses a smaller draft model to propose tokens for faster inference. |
+| Stakeholder brief | Concise update summarizing status, risks, asks, and next steps for stakeholders. |
+| Telemetry | Instrumentation data (metrics, logs, traces) collected from systems. |
+| Tokenization | Converting text into discrete units (tokens) consumed by the model. |
+| Vector store | Database optimized for storing and retrieving embeddings. |
+| Workflow trace | Timeline of actions taken by an agent or system for transparency and debugging. |
+| Zero-shot | Prompting a model without providing examples. |
+
+## What’s Next
+- **Specialize further:** Explore reinforcement learning (RLHF, DPO), agent safety research, or multimodal generation using the resources listed above.
+- **Join communities:** Participate in Papers We Love chapters, local MLOps meetups, or online study groups to keep learning.
+- **Contribute back:** Submit project templates, add evaluation datasets, or write case studies documenting production lessons.
+- **Mentor others:** Host office hours, run study sessions, and help newcomers adopt responsible AI practices.
+- **Stay current:** Review links quarterly (see Maintenance Plan) and subscribe to reputable newsletters (e.g., The Batch, Latent Space) for emerging practices.

--- a/RESOURCES.json
+++ b/RESOURCES.json
@@ -1,0 +1,738 @@
+{
+  "Orientation & Study Plan": [
+    {
+      "title": "KAUST Generative AI Training Curriculum",
+      "url": "https://github.com/kaust-generative-ai/training-curriculum",
+      "format": "Curriculum",
+      "level": "Beginner",
+      "est_time_hrs": 6,
+      "why": "Sets expectations for weekly cadence and gives a structured campus-style plan you can adapt to your own schedule."
+    },
+    {
+      "title": "GenAI Curriculum Tracker",
+      "url": "https://github.com/nckclrk/generative-ai-curriculum",
+      "format": "Workbook",
+      "level": "Beginner",
+      "est_time_hrs": 3,
+      "why": "Provides checklist-driven study logs and note templates for keeping an experiment journal."
+    },
+    {
+      "title": "Microsoft Generative AI for Beginners",
+      "url": "https://github.com/microsoft/generative-ai-for-beginners",
+      "format": "Course",
+      "level": "Beginner",
+      "est_time_hrs": 20,
+      "why": "Offers a comprehensive syllabus you can pace at 4/8/12/24 week intervals with clear module outcomes."
+    }
+  ],
+  "Module 00 \u00b7 Introduction": [
+    {
+      "title": "fastai fastsetup",
+      "url": "https://github.com/fastai/fastsetup",
+      "format": "Setup guide",
+      "level": "Beginner",
+      "est_time_hrs": 1,
+      "why": "Walks through reliable Python environment bootstrapping on Windows, macOS, and Linux."
+    },
+    {
+      "title": "Google Colab Tools",
+      "url": "https://github.com/googlecolab/colabtools",
+      "format": "Documentation",
+      "level": "Beginner",
+      "est_time_hrs": 1,
+      "why": "Explains cloud notebook workflows, GPU quotas, and collaboration tips for quick experiments."
+    },
+    {
+      "title": "dair-ai Machine Learning YouTube Courses",
+      "url": "https://github.com/dair-ai/ML-YouTube-Courses",
+      "format": "Playlist index",
+      "level": "Beginner",
+      "est_time_hrs": 8,
+      "why": "Curates high-quality video series to slot into your personal learning sprint."
+    }
+  ],
+  "Module 01 \u00b7 GenAI Fundamentals": [
+    {
+      "title": "OpenAI Cookbook",
+      "url": "https://github.com/openai/openai-cookbook",
+      "format": "Cookbook",
+      "level": "Beginner",
+      "est_time_hrs": 6,
+      "why": "Covers API basics, embeddings, and prompt iteration with runnable notebooks."
+    },
+    {
+      "title": "Hugging Face Transformers",
+      "url": "https://github.com/huggingface/transformers",
+      "format": "Library docs",
+      "level": "Intermediate",
+      "est_time_hrs": 10,
+      "why": "Teaches model architectures, tokenizers, and inference utilities with examples."
+    },
+    {
+      "title": "Karpathy LLM101n",
+      "url": "https://github.com/karpathy/LLM101n",
+      "format": "Course",
+      "level": "Intermediate",
+      "est_time_hrs": 12,
+      "why": "Demystifies transformer math with annotated code and lecture videos."
+    }
+  ],
+  "Math for GenAI": [
+    {
+      "title": "nn-zero-to-hero",
+      "url": "https://github.com/karpathy/nn-zero-to-hero",
+      "format": "Course",
+      "level": "Beginner",
+      "est_time_hrs": 10,
+      "why": "Refreshes calculus and optimization intuition with code-first notebooks."
+    },
+    {
+      "title": "Numerical Linear Algebra",
+      "url": "https://github.com/fastai/numerical-linear-algebra",
+      "format": "Book",
+      "level": "Intermediate",
+      "est_time_hrs": 12,
+      "why": "Focuses on matrix decompositions that power embeddings and attention."
+    },
+    {
+      "title": "Math for ML",
+      "url": "https://github.com/cadizm/math-for-ml",
+      "format": "Notes",
+      "level": "Beginner",
+      "est_time_hrs": 5,
+      "why": "Summarizes probability and vector math essentials for GenAI prompts and loss functions."
+    }
+  ],
+  "Module 02 \u00b7 Prompting & Structured Outputs": [
+    {
+      "title": "Prompt Engineering Guide",
+      "url": "https://github.com/dair-ai/Prompt-Engineering-Guide",
+      "format": "Guide",
+      "level": "Intermediate",
+      "est_time_hrs": 6,
+      "why": "Collects tested prompt patterns with JSON schema examples."
+    },
+    {
+      "title": "Awesome Prompt Engineering",
+      "url": "https://github.com/promptslab/Awesome-Prompt-Engineering",
+      "format": "Repository",
+      "level": "Intermediate",
+      "est_time_hrs": 4,
+      "why": "Provides tooling references and benchmarks for structured outputs."
+    },
+    {
+      "title": "Outlines",
+      "url": "https://github.com/outlines-dev/outlines",
+      "format": "Library",
+      "level": "Intermediate",
+      "est_time_hrs": 3,
+      "why": "Offers deterministic prompting utilities for JSON, regex, and CFG-constrained outputs."
+    }
+  ],
+  "Prompt Engineering Essentials": [
+    {
+      "title": "Google Cloud Generative AI Examples",
+      "url": "https://github.com/GoogleCloudPlatform/generative-ai",
+      "format": "Examples",
+      "level": "Beginner",
+      "est_time_hrs": 5,
+      "why": "Demonstrates role/task/format prompting across Vertex AI and open models."
+    },
+    {
+      "title": "Anthropic Cookbook",
+      "url": "https://github.com/anthropics/anthropic-cookbook",
+      "format": "Cookbook",
+      "level": "Intermediate",
+      "est_time_hrs": 6,
+      "why": "Shows Claude function-calling, safety filters, and evaluation loops."
+    },
+    {
+      "title": "Microsoft Promptflow",
+      "url": "https://github.com/microsoft/promptflow",
+      "format": "Framework",
+      "level": "Intermediate",
+      "est_time_hrs": 5,
+      "why": "Adds reproducible prompt pipelines with versioned inputs and outputs."
+    }
+  ],
+  "Module 03 \u00b7 Agents & Orchestration": [
+    {
+      "title": "LangGraph",
+      "url": "https://github.com/langchain-ai/langgraph",
+      "format": "Framework",
+      "level": "Intermediate",
+      "est_time_hrs": 5,
+      "why": "Implements stateful agent workflows with guardrails and retries."
+    },
+    {
+      "title": "Marvin",
+      "url": "https://github.com/PrefectHQ/marvin",
+      "format": "Framework",
+      "level": "Intermediate",
+      "est_time_hrs": 4,
+      "why": "Shows pragmatic agent orchestration with Prefect observability hooks."
+    },
+    {
+      "title": "Semantic Kernel",
+      "url": "https://github.com/microsoft/semantic-kernel",
+      "format": "SDK",
+      "level": "Intermediate",
+      "est_time_hrs": 6,
+      "why": "Blends planners, connectors, and memory for enterprise-grade orchestration."
+    }
+  ],
+  "Agents & Tool-Use": [
+    {
+      "title": "AutoGen",
+      "url": "https://github.com/microsoft/autogen",
+      "format": "Framework",
+      "level": "Advanced",
+      "est_time_hrs": 8,
+      "why": "Explores multi-agent collaboration, human-in-the-loop, and tool routing."
+    },
+    {
+      "title": "Langroid",
+      "url": "https://github.com/langroid/langroid",
+      "format": "Framework",
+      "level": "Advanced",
+      "est_time_hrs": 6,
+      "why": "Focuses on deterministic tool contracts and streaming traces."
+    },
+    {
+      "title": "Tool Calling Guide",
+      "url": "https://github.com/ALucek/tool-calling-guide",
+      "format": "Guide",
+      "level": "Intermediate",
+      "est_time_hrs": 2,
+      "why": "Summarizes function schema design and safety patterns for external tools."
+    }
+  ],
+  "Module 04 \u00b7 RAG Essentials": [
+    {
+      "title": "LlamaIndex",
+      "url": "https://github.com/jerryjliu/llama_index",
+      "format": "Framework",
+      "level": "Intermediate",
+      "est_time_hrs": 6,
+      "why": "Covers indices, retrievers, and evaluators for small-to-medium RAG stacks."
+    },
+    {
+      "title": "Pinecone Examples",
+      "url": "https://github.com/pinecone-io/examples",
+      "format": "Examples",
+      "level": "Intermediate",
+      "est_time_hrs": 4,
+      "why": "Demonstrates hybrid search, metadata filters, and streaming inserts."
+    },
+    {
+      "title": "Haystack",
+      "url": "https://github.com/deepset-ai/haystack",
+      "format": "Framework",
+      "level": "Intermediate",
+      "est_time_hrs": 6,
+      "why": "Provides modular pipelines for retrievers, rerankers, and evaluators."
+    }
+  ],
+  "Retrieval-Augmented Generation": [
+    {
+      "title": "GraphRAG",
+      "url": "https://github.com/microsoft/graphrag",
+      "format": "Toolkit",
+      "level": "Advanced",
+      "est_time_hrs": 6,
+      "why": "Shows how to capture entity graphs for high-context retrieval."
+    },
+    {
+      "title": "fastRAG",
+      "url": "https://github.com/IntelLabs/fastRAG",
+      "format": "Toolkit",
+      "level": "Advanced",
+      "est_time_hrs": 5,
+      "why": "Benchmarks latency, cost, and accuracy trade-offs across RAG configurations."
+    },
+    {
+      "title": "Awesome GraphRAG",
+      "url": "https://github.com/DEEP-PolyU/Awesome-GraphRAG",
+      "format": "Curated list",
+      "level": "Advanced",
+      "est_time_hrs": 3,
+      "why": "Aggregates research, frameworks, and datasets for graph-enhanced RAG."
+    }
+  ],
+  "Module 05 \u00b7 Evaluation & Observability": [
+    {
+      "title": "Ragas",
+      "url": "https://github.com/explodinggradients/ragas",
+      "format": "Library",
+      "level": "Intermediate",
+      "est_time_hrs": 4,
+      "why": "Implements retrieval and answer quality metrics with dataset scaffolding."
+    },
+    {
+      "title": "promptfoo",
+      "url": "https://github.com/promptfoo/promptfoo",
+      "format": "CLI",
+      "level": "Intermediate",
+      "est_time_hrs": 3,
+      "why": "Automates prompt regression tests with diff-friendly outputs."
+    },
+    {
+      "title": "Langfuse",
+      "url": "https://github.com/langfuse/langfuse",
+      "format": "Platform",
+      "level": "Intermediate",
+      "est_time_hrs": 5,
+      "why": "Delivers tracing, analytics, and user feedback dashboards for LLM apps."
+    },
+    {
+      "title": "TruLens",
+      "url": "https://github.com/truera/trulens",
+      "format": "Framework",
+      "level": "Intermediate",
+      "est_time_hrs": 4,
+      "why": "Adds evaluator suites and guardrail policies with audit trails."
+    }
+  ],
+  "Evaluation & Evals": [
+    {
+      "title": "InstructEval",
+      "url": "https://github.com/declare-lab/instruct-eval",
+      "format": "Benchmark",
+      "level": "Advanced",
+      "est_time_hrs": 4,
+      "why": "Provides task-specific evaluation datasets for instruction-tuned models."
+    },
+    {
+      "title": "BigCode Evaluation Harness",
+      "url": "https://github.com/bigcode-project/bigcode-evaluation-harness",
+      "format": "Benchmark",
+      "level": "Advanced",
+      "est_time_hrs": 6,
+      "why": "Standardizes code-generation metrics, baselines, and prompts."
+    },
+    {
+      "title": "HELM",
+      "url": "https://github.com/stanford-crfm/helm",
+      "format": "Benchmark",
+      "level": "Advanced",
+      "est_time_hrs": 8,
+      "why": "Offers a broad evaluation framework with safety and efficiency slices."
+    }
+  ],
+  "Module 06 \u00b7 Serving & Inference": [
+    {
+      "title": "vLLM",
+      "url": "https://github.com/vllm-project/vllm",
+      "format": "Inference engine",
+      "level": "Intermediate",
+      "est_time_hrs": 5,
+      "why": "Teaches paged KV-cache serving with OpenAI-compatible APIs."
+    },
+    {
+      "title": "Text Generation Inference",
+      "url": "https://github.com/huggingface/text-generation-inference",
+      "format": "Inference server",
+      "level": "Intermediate",
+      "est_time_hrs": 5,
+      "why": "Demonstrates managed deployment patterns and streaming responses."
+    },
+    {
+      "title": "TensorRT-LLM",
+      "url": "https://github.com/NVIDIA/TensorRT-LLM",
+      "format": "Toolkit",
+      "level": "Advanced",
+      "est_time_hrs": 6,
+      "why": "Covers GPU-optimized inference, quantization, and serving pipelines."
+    }
+  ],
+  "Module 07 \u00b7 Performance & Cost Optimization": [
+    {
+      "title": "LLM-AWQ",
+      "url": "https://github.com/mit-han-lab/llm-awq",
+      "format": "Library",
+      "level": "Advanced",
+      "est_time_hrs": 4,
+      "why": "Explains activation-aware quantization with benchmarks."
+    },
+    {
+      "title": "LLM Perf Bench",
+      "url": "https://github.com/mlc-ai/llm-perf-bench",
+      "format": "Benchmark",
+      "level": "Advanced",
+      "est_time_hrs": 5,
+      "why": "Provides scripts to profile latency, throughput, and memory under load."
+    },
+    {
+      "title": "lit-gpt",
+      "url": "https://github.com/Lightning-AI/litgpt",
+      "format": "Framework",
+      "level": "Intermediate",
+      "est_time_hrs": 6,
+      "why": "Combines quantization, LoRA, and efficient serving recipes."
+    }
+  ],
+  "Module 08 \u00b7 Vector Search": [
+    {
+      "title": "FAISS",
+      "url": "https://github.com/facebookresearch/faiss",
+      "format": "Library",
+      "level": "Intermediate",
+      "est_time_hrs": 6,
+      "why": "Covers index types, IVF parameters, and GPU acceleration."
+    },
+    {
+      "title": "pgvector",
+      "url": "https://github.com/pgvector/pgvector",
+      "format": "Extension",
+      "level": "Intermediate",
+      "est_time_hrs": 4,
+      "why": "Shows how to add vector search to PostgreSQL with hybrid queries."
+    },
+    {
+      "title": "Milvus",
+      "url": "https://github.com/milvus-io/milvus",
+      "format": "Vector database",
+      "level": "Intermediate",
+      "est_time_hrs": 6,
+      "why": "Provides production-scale vector indexing with horizontal scaling."
+    }
+  ],
+  "Module 09 \u00b7 Security & Safety": [
+    {
+      "title": "OWASP Top 10 for LLM Applications",
+      "url": "https://github.com/OWASP/www-project-top-10-for-large-language-model-applications",
+      "format": "Guide",
+      "level": "Intermediate",
+      "est_time_hrs": 3,
+      "why": "Defines common GenAI threat vectors and mitigations."
+    },
+    {
+      "title": "NeMo Guardrails",
+      "url": "https://github.com/NVIDIA/NeMo-Guardrails",
+      "format": "Framework",
+      "level": "Intermediate",
+      "est_time_hrs": 5,
+      "why": "Implements policy-based guardrails for chat, RAG, and tool agents."
+    },
+    {
+      "title": "Rebuff",
+      "url": "https://github.com/protectai/rebuff",
+      "format": "Toolkit",
+      "level": "Intermediate",
+      "est_time_hrs": 4,
+      "why": "Adds prompt injection detection with sandboxed tool execution."
+    }
+  ],
+  "Security, Privacy & Compliance": [
+    {
+      "title": "AI Privacy Checklist",
+      "url": "https://github.com/JariPesonen/AIPrivacyChecklist",
+      "format": "Checklist",
+      "level": "Intermediate",
+      "est_time_hrs": 2,
+      "why": "Outlines privacy impact questions for model development."
+    },
+    {
+      "title": "AI Privacy Toolkit",
+      "url": "https://github.com/IBM/ai-privacy-toolkit",
+      "format": "Toolkit",
+      "level": "Advanced",
+      "est_time_hrs": 5,
+      "why": "Provides differential privacy utilities and policy templates."
+    },
+    {
+      "title": "AI Compliance Auditor",
+      "url": "https://github.com/awsdataarchitect/ai-compliance-auditor",
+      "format": "Toolkit",
+      "level": "Intermediate",
+      "est_time_hrs": 4,
+      "why": "Demonstrates automated checks for data retention and access controls."
+    }
+  ],
+  "Module 10 \u00b7 Governance & Compliance": [
+    {
+      "title": "EU AI Act Notes",
+      "url": "https://github.com/daveshap/EU_AI_Act",
+      "format": "Notes",
+      "level": "Intermediate",
+      "est_time_hrs": 4,
+      "why": "Summarizes obligations by risk class with quick reference tables."
+    },
+    {
+      "title": "AI Governance Playbook",
+      "url": "https://github.com/Neetu-kapoor/Ai-governance-playbook",
+      "format": "Playbook",
+      "level": "Intermediate",
+      "est_time_hrs": 3,
+      "why": "Provides governance charters, RACI templates, and stakeholder maps."
+    },
+    {
+      "title": "AI Governance Risk & Compliance Docs",
+      "url": "https://github.com/ahsan-141117/AI-Governance-Risk-Compliance-Documentation",
+      "format": "Templates",
+      "level": "Intermediate",
+      "est_time_hrs": 3,
+      "why": "Includes audit-ready checklists and policy samples for GenAI programs."
+    }
+  ],
+  "Responsible AI & Governance": [
+    {
+      "title": "Awesome Responsible AI",
+      "url": "https://github.com/AthenaCore/AwesomeResponsibleAI",
+      "format": "Curated list",
+      "level": "Intermediate",
+      "est_time_hrs": 6,
+      "why": "Aggregates research, tooling, and case studies on responsible AI."
+    },
+    {
+      "title": "Responsible AI Toolbox",
+      "url": "https://github.com/microsoft/responsible-ai-toolbox",
+      "format": "Toolkit",
+      "level": "Intermediate",
+      "est_time_hrs": 6,
+      "why": "Provides model interpretability, fairness, and error analysis dashboards."
+    },
+    {
+      "title": "Awesome ML Model Governance",
+      "url": "https://github.com/visenger/Awesome-ML-Model-Governance",
+      "format": "Curated list",
+      "level": "Intermediate",
+      "est_time_hrs": 4,
+      "why": "Offers frameworks for lifecycle governance, approvals, and audits."
+    }
+  ],
+  "Module 11 \u00b7 Edge & Embedded": [
+    {
+      "title": "Edge AI for Beginners",
+      "url": "https://github.com/microsoft/edgeai-for-beginners",
+      "format": "Course",
+      "level": "Intermediate",
+      "est_time_hrs": 10,
+      "why": "Covers hardware-aware deployment and telemetry for small models."
+    },
+    {
+      "title": "ONNX Runtime GenAI",
+      "url": "https://github.com/microsoft/onnxruntime-genai",
+      "format": "Toolkit",
+      "level": "Intermediate",
+      "est_time_hrs": 5,
+      "why": "Shows how to run quantized models on CPU, GPU, and mobile."
+    },
+    {
+      "title": "Phi-3 Mini Samples",
+      "url": "https://github.com/Azure-Samples/Phi-3MiniSamples",
+      "format": "Examples",
+      "level": "Intermediate",
+      "est_time_hrs": 4,
+      "why": "Demonstrates on-device SLM workflows with telemetry capture."
+    }
+  ],
+  "Fine-Tuning & Adapters": [
+    {
+      "title": "PEFT",
+      "url": "https://github.com/huggingface/peft",
+      "format": "Library",
+      "level": "Intermediate",
+      "est_time_hrs": 5,
+      "why": "Implements LoRA, QLoRA, and other parameter-efficient adapters."
+    },
+    {
+      "title": "QLoRA",
+      "url": "https://github.com/artidoro/qlora",
+      "format": "Toolkit",
+      "level": "Advanced",
+      "est_time_hrs": 6,
+      "why": "Explains low-bit fine-tuning with reproducible scripts."
+    },
+    {
+      "title": "Open Instruct",
+      "url": "https://github.com/allenai/open-instruct",
+      "format": "Dataset & recipes",
+      "level": "Advanced",
+      "est_time_hrs": 8,
+      "why": "Provides supervised fine-tuning data pipelines and evaluation baselines."
+    }
+  ],
+  "Multimodal": [
+    {
+      "title": "LLaVA",
+      "url": "https://github.com/haotian-liu/LLaVA",
+      "format": "Model",
+      "level": "Advanced",
+      "est_time_hrs": 6,
+      "why": "Demonstrates visual instruction tuning and captioning workflows."
+    },
+    {
+      "title": "Segment Anything",
+      "url": "https://github.com/facebookresearch/segment-anything",
+      "format": "Model",
+      "level": "Intermediate",
+      "est_time_hrs": 5,
+      "why": "Provides image segmentation building blocks for multimodal agents."
+    },
+    {
+      "title": "Whisper",
+      "url": "https://github.com/openai/whisper",
+      "format": "Model",
+      "level": "Intermediate",
+      "est_time_hrs": 4,
+      "why": "Gives ready-to-run speech transcription pipelines for audio augmentation."
+    }
+  ],
+  "LLMOps & MLE for Leaders": [
+    {
+      "title": "Awesome LLMOps",
+      "url": "https://github.com/tensorchord/Awesome-LLMOps",
+      "format": "Curated list",
+      "level": "Intermediate",
+      "est_time_hrs": 6,
+      "why": "Maps the vendor and open-source landscape for monitoring, deployment, and controls."
+    },
+    {
+      "title": "LLM Engineer's Handbook",
+      "url": "https://github.com/PacktPublishing/LLM-Engineers-Handbook",
+      "format": "Book code",
+      "level": "Intermediate",
+      "est_time_hrs": 10,
+      "why": "Includes project templates, release checklists, and operational metrics."
+    },
+    {
+      "title": "OpenLLMetry",
+      "url": "https://github.com/traceloop/openllmetry",
+      "format": "Toolkit",
+      "level": "Advanced",
+      "est_time_hrs": 5,
+      "why": "Instrument LLM apps with OpenTelemetry for observability and governance."
+    }
+  ],
+  "Module 12 \u00b7 Portfolio Patterns": [
+    {
+      "title": "GenAI Projects Portfolio",
+      "url": "https://github.com/Ashleshk/GenAI-Projects-Portfolio",
+      "format": "Examples",
+      "level": "Beginner",
+      "est_time_hrs": 3,
+      "why": "Offers portfolio layout ideas with metrics-driven writeups."
+    },
+    {
+      "title": "SAP BTP GenAI Starter Kit",
+      "url": "https://github.com/SAP-samples/btp-genai-starter-kit",
+      "format": "Starter kit",
+      "level": "Intermediate",
+      "est_time_hrs": 6,
+      "why": "Includes production-ready project scaffolds and deployment scripts."
+    },
+    {
+      "title": "AWS Agentic AI Demos",
+      "url": "https://github.com/aws-samples/sample-agentic-ai-demos",
+      "format": "Examples",
+      "level": "Intermediate",
+      "est_time_hrs": 5,
+      "why": "Showcases multi-agent demos with architecture diagrams and KPIs."
+    }
+  ],
+  "Architecture Patterns": [
+    {
+      "title": "Modular RAG",
+      "url": "https://github.com/ThomasVitale/modular-rag",
+      "format": "Guide",
+      "level": "Intermediate",
+      "est_time_hrs": 4,
+      "why": "Breaks RAG systems into repeatable modules with architecture diagrams."
+    },
+    {
+      "title": "LLM Multi-Agent Patterns",
+      "url": "https://github.com/VinZCodz/llm_multi_agent_patterns",
+      "format": "Guide",
+      "level": "Advanced",
+      "est_time_hrs": 4,
+      "why": "Explains when to choose planner/worker, reflection, and critique loops."
+    },
+    {
+      "title": "Kernel Memory",
+      "url": "https://github.com/microsoft/kernel-memory",
+      "format": "Framework",
+      "level": "Intermediate",
+      "est_time_hrs": 5,
+      "why": "Demonstrates memory-first architectures with ingestion, chunking, and retrieval services."
+    }
+  ],
+  "Portfolio & Interview Prep": [
+    {
+      "title": "GenAI Interview Questions",
+      "url": "https://github.com/a-tabaza/genai_interview_questions",
+      "format": "Question bank",
+      "level": "Intermediate",
+      "est_time_hrs": 4,
+      "why": "Curates current GenAI system design and scenario prompts."
+    },
+    {
+      "title": "MLE/DS Interview Prep Guide",
+      "url": "https://github.com/whaleonearth/MLE-DS-Interview-Prep-Guide",
+      "format": "Guide",
+      "level": "Intermediate",
+      "est_time_hrs": 6,
+      "why": "Provides behavioral prompts, take-home tips, and technical refreshers."
+    },
+    {
+      "title": "Andreis Interview Handbook",
+      "url": "https://github.com/andreis/interview",
+      "format": "Guide",
+      "level": "Intermediate",
+      "est_time_hrs": 8,
+      "why": "Gives structured preparation checklists and storytelling frameworks."
+    }
+  ],
+  "Community & Mentoring": [
+    {
+      "title": "Mentorship Guide Docs",
+      "url": "https://github.com/mentorship-sponsorship/mentorship-guide-docs",
+      "format": "Guide",
+      "level": "Beginner",
+      "est_time_hrs": 2,
+      "why": "Explains how to run mentorship agreements and feedback loops."
+    },
+    {
+      "title": "The Open Source Way Guidebook",
+      "url": "https://github.com/theopensourceway/guidebook",
+      "format": "Guidebook",
+      "level": "Intermediate",
+      "est_time_hrs": 6,
+      "why": "Details community-of-practice facilitation and governance tactics."
+    },
+    {
+      "title": "Papers We Love",
+      "url": "https://github.com/papers-we-love/papers-we-love",
+      "format": "Community",
+      "level": "Intermediate",
+      "est_time_hrs": 6,
+      "why": "Models an open study group with reading checklists and meetup templates."
+    }
+  ],
+  "Tooling & Environment Setup": [
+    {
+      "title": "Miniforge",
+      "url": "https://github.com/conda-forge/miniforge",
+      "format": "Installer",
+      "level": "Beginner",
+      "est_time_hrs": 1,
+      "why": "Lightweight conda distribution for reproducible Python environments."
+    },
+    {
+      "title": "VS Code Dev Containers",
+      "url": "https://github.com/microsoft/vscode-dev-containers",
+      "format": "Templates",
+      "level": "Intermediate",
+      "est_time_hrs": 3,
+      "why": "Provides ready-to-use containerized development environments."
+    },
+    {
+      "title": "runpodctl",
+      "url": "https://github.com/runpod/runpodctl",
+      "format": "CLI",
+      "level": "Intermediate",
+      "est_time_hrs": 2,
+      "why": "Helps manage on-demand GPU pods for cloud training and inference."
+    }
+  ]
+}

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,30 @@
+# Roadmap
+
+## Q4 2025
+- **Launch module refresh cycle.** Review all resource links, replace outdated items, and expand TODO ideas into new subsections.
+- **Portfolio templates.** Add sample filled-in project brief, model card, and experiment log entries sourced from contributors.
+- **Automation setup.** Add link-checking CI and Markdown linting to keep docs healthy.
+
+## Q1 2026
+- **Evaluation deep dive.** Introduce advanced evaluation case studies (human-in-the-loop, LLM-as-a-judge safeguards) and update the Evaluation & Evals workflow.
+- **Leadership tooling.** Publish templates for stakeholder updates, risk dashboards, and governance briefs.
+- **Community pilots.** Host the first remote study group, capture facilitation notes, and add them to the Community & Mentoring section.
+
+## Q2 2026
+- **New modalities.** Expand the Multimodal section with audio-to-action and video summarization resources plus lab ideas.
+- **Ops maturity.** Document incident response playbooks and cost optimization calculators aligned with the Project Leadership Playbook.
+- **Contributor onboarding.** Create a PR template, issue templates, and recorded walkthrough for new contributors.
+
+## Milestones & Learning Outcomes
+| Milestone | Target Date | Description | Learning Outcomes |
+| --- | --- | --- | --- |
+| Foundations refresh | 2025-12-15 | Complete review of Phase 1 resources and mini-tasks. | Stronger grasp of prompting, math, and fundamentals. |
+| RAG & Evaluation sprint | 2026-02-28 | Expand RAG/Eval sections with new case studies and templates. | Ability to build and evaluate production-ready knowledge systems. |
+| Governance toolkit v2 | 2026-04-30 | Publish additional governance artifacts and workflows. | Leaders can run audits, risk reviews, and stakeholder comms with confidence. |
+
+## Open Calls for Contribution
+- Help test and document GPU/devcontainer setups across platforms.
+- Share anonymized governance briefs, risk registers, or fairness reviews to enrich templates.
+- Contribute project walkthroughs (videos, blog posts) highlighting how you used the curriculum to ship real solutions.
+
+Track progress and suggest additions via GitHub issues labelled `roadmap`.

--- a/write_resources.py
+++ b/write_resources.py
@@ -1,0 +1,743 @@
+import json
+
+resources = {
+    "Orientation & Study Plan": [
+        {
+            "title": "KAUST Generative AI Training Curriculum",
+            "url": "https://github.com/kaust-generative-ai/training-curriculum",
+            "format": "Curriculum",
+            "level": "Beginner",
+            "est_time_hrs": 6,
+            "why": "Sets expectations for weekly cadence and gives a structured campus-style plan you can adapt to your own schedule."
+        },
+        {
+            "title": "GenAI Curriculum Tracker",
+            "url": "https://github.com/nckclrk/generative-ai-curriculum",
+            "format": "Workbook",
+            "level": "Beginner",
+            "est_time_hrs": 3,
+            "why": "Provides checklist-driven study logs and note templates for keeping an experiment journal."
+        },
+        {
+            "title": "Microsoft Generative AI for Beginners",
+            "url": "https://github.com/microsoft/generative-ai-for-beginners",
+            "format": "Course",
+            "level": "Beginner",
+            "est_time_hrs": 20,
+            "why": "Offers a comprehensive syllabus you can pace at 4/8/12/24 week intervals with clear module outcomes."
+        }
+    ],
+    "Module 00 · Introduction": [
+        {
+            "title": "fastai fastsetup",
+            "url": "https://github.com/fastai/fastsetup",
+            "format": "Setup guide",
+            "level": "Beginner",
+            "est_time_hrs": 1,
+            "why": "Walks through reliable Python environment bootstrapping on Windows, macOS, and Linux."
+        },
+        {
+            "title": "Google Colab Tools",
+            "url": "https://github.com/googlecolab/colabtools",
+            "format": "Documentation",
+            "level": "Beginner",
+            "est_time_hrs": 1,
+            "why": "Explains cloud notebook workflows, GPU quotas, and collaboration tips for quick experiments."
+        },
+        {
+            "title": "dair-ai Machine Learning YouTube Courses",
+            "url": "https://github.com/dair-ai/ML-YouTube-Courses",
+            "format": "Playlist index",
+            "level": "Beginner",
+            "est_time_hrs": 8,
+            "why": "Curates high-quality video series to slot into your personal learning sprint."
+        }
+    ],
+    "Module 01 · GenAI Fundamentals": [
+        {
+            "title": "OpenAI Cookbook",
+            "url": "https://github.com/openai/openai-cookbook",
+            "format": "Cookbook",
+            "level": "Beginner",
+            "est_time_hrs": 6,
+            "why": "Covers API basics, embeddings, and prompt iteration with runnable notebooks."
+        },
+        {
+            "title": "Hugging Face Transformers",
+            "url": "https://github.com/huggingface/transformers",
+            "format": "Library docs",
+            "level": "Intermediate",
+            "est_time_hrs": 10,
+            "why": "Teaches model architectures, tokenizers, and inference utilities with examples."
+        },
+        {
+            "title": "Karpathy LLM101n",
+            "url": "https://github.com/karpathy/LLM101n",
+            "format": "Course",
+            "level": "Intermediate",
+            "est_time_hrs": 12,
+            "why": "Demystifies transformer math with annotated code and lecture videos."
+        }
+    ],
+    "Math for GenAI": [
+        {
+            "title": "nn-zero-to-hero",
+            "url": "https://github.com/karpathy/nn-zero-to-hero",
+            "format": "Course",
+            "level": "Beginner",
+            "est_time_hrs": 10,
+            "why": "Refreshes calculus and optimization intuition with code-first notebooks."
+        },
+        {
+            "title": "Numerical Linear Algebra",
+            "url": "https://github.com/fastai/numerical-linear-algebra",
+            "format": "Book",
+            "level": "Intermediate",
+            "est_time_hrs": 12,
+            "why": "Focuses on matrix decompositions that power embeddings and attention."
+        },
+        {
+            "title": "Math for ML",
+            "url": "https://github.com/cadizm/math-for-ml",
+            "format": "Notes",
+            "level": "Beginner",
+            "est_time_hrs": 5,
+            "why": "Summarizes probability and vector math essentials for GenAI prompts and loss functions."
+        }
+    ],
+    "Module 02 · Prompting & Structured Outputs": [
+        {
+            "title": "Prompt Engineering Guide",
+            "url": "https://github.com/dair-ai/Prompt-Engineering-Guide",
+            "format": "Guide",
+            "level": "Intermediate",
+            "est_time_hrs": 6,
+            "why": "Collects tested prompt patterns with JSON schema examples."
+        },
+        {
+            "title": "Awesome Prompt Engineering",
+            "url": "https://github.com/promptslab/Awesome-Prompt-Engineering",
+            "format": "Repository",
+            "level": "Intermediate",
+            "est_time_hrs": 4,
+            "why": "Provides tooling references and benchmarks for structured outputs."
+        },
+        {
+            "title": "Outlines",
+            "url": "https://github.com/outlines-dev/outlines",
+            "format": "Library",
+            "level": "Intermediate",
+            "est_time_hrs": 3,
+            "why": "Offers deterministic prompting utilities for JSON, regex, and CFG-constrained outputs."
+        }
+    ],
+    "Prompt Engineering Essentials": [
+        {
+            "title": "Google Cloud Generative AI Examples",
+            "url": "https://github.com/GoogleCloudPlatform/generative-ai",
+            "format": "Examples",
+            "level": "Beginner",
+            "est_time_hrs": 5,
+            "why": "Demonstrates role/task/format prompting across Vertex AI and open models."
+        },
+        {
+            "title": "Anthropic Cookbook",
+            "url": "https://github.com/anthropics/anthropic-cookbook",
+            "format": "Cookbook",
+            "level": "Intermediate",
+            "est_time_hrs": 6,
+            "why": "Shows Claude function-calling, safety filters, and evaluation loops."
+        },
+        {
+            "title": "Microsoft Promptflow",
+            "url": "https://github.com/microsoft/promptflow",
+            "format": "Framework",
+            "level": "Intermediate",
+            "est_time_hrs": 5,
+            "why": "Adds reproducible prompt pipelines with versioned inputs and outputs."
+        }
+    ],
+    "Module 03 · Agents & Orchestration": [
+        {
+            "title": "LangGraph",
+            "url": "https://github.com/langchain-ai/langgraph",
+            "format": "Framework",
+            "level": "Intermediate",
+            "est_time_hrs": 5,
+            "why": "Implements stateful agent workflows with guardrails and retries."
+        },
+        {
+            "title": "Marvin",
+            "url": "https://github.com/PrefectHQ/marvin",
+            "format": "Framework",
+            "level": "Intermediate",
+            "est_time_hrs": 4,
+            "why": "Shows pragmatic agent orchestration with Prefect observability hooks."
+        },
+        {
+            "title": "Semantic Kernel",
+            "url": "https://github.com/microsoft/semantic-kernel",
+            "format": "SDK",
+            "level": "Intermediate",
+            "est_time_hrs": 6,
+            "why": "Blends planners, connectors, and memory for enterprise-grade orchestration."
+        }
+    ],
+    "Agents & Tool-Use": [
+        {
+            "title": "AutoGen",
+            "url": "https://github.com/microsoft/autogen",
+            "format": "Framework",
+            "level": "Advanced",
+            "est_time_hrs": 8,
+            "why": "Explores multi-agent collaboration, human-in-the-loop, and tool routing."
+        },
+        {
+            "title": "Langroid",
+            "url": "https://github.com/langroid/langroid",
+            "format": "Framework",
+            "level": "Advanced",
+            "est_time_hrs": 6,
+            "why": "Focuses on deterministic tool contracts and streaming traces."
+        },
+        {
+            "title": "Tool Calling Guide",
+            "url": "https://github.com/ALucek/tool-calling-guide",
+            "format": "Guide",
+            "level": "Intermediate",
+            "est_time_hrs": 2,
+            "why": "Summarizes function schema design and safety patterns for external tools."
+        }
+    ],
+    "Module 04 · RAG Essentials": [
+        {
+            "title": "LlamaIndex",
+            "url": "https://github.com/jerryjliu/llama_index",
+            "format": "Framework",
+            "level": "Intermediate",
+            "est_time_hrs": 6,
+            "why": "Covers indices, retrievers, and evaluators for small-to-medium RAG stacks."
+        },
+        {
+            "title": "Pinecone Examples",
+            "url": "https://github.com/pinecone-io/examples",
+            "format": "Examples",
+            "level": "Intermediate",
+            "est_time_hrs": 4,
+            "why": "Demonstrates hybrid search, metadata filters, and streaming inserts."
+        },
+        {
+            "title": "Haystack",
+            "url": "https://github.com/deepset-ai/haystack",
+            "format": "Framework",
+            "level": "Intermediate",
+            "est_time_hrs": 6,
+            "why": "Provides modular pipelines for retrievers, rerankers, and evaluators."
+        }
+    ],
+    "Retrieval-Augmented Generation": [
+        {
+            "title": "GraphRAG",
+            "url": "https://github.com/microsoft/graphrag",
+            "format": "Toolkit",
+            "level": "Advanced",
+            "est_time_hrs": 6,
+            "why": "Shows how to capture entity graphs for high-context retrieval."
+        },
+        {
+            "title": "fastRAG",
+            "url": "https://github.com/IntelLabs/fastRAG",
+            "format": "Toolkit",
+            "level": "Advanced",
+            "est_time_hrs": 5,
+            "why": "Benchmarks latency, cost, and accuracy trade-offs across RAG configurations."
+        },
+        {
+            "title": "Awesome GraphRAG",
+            "url": "https://github.com/DEEP-PolyU/Awesome-GraphRAG",
+            "format": "Curated list",
+            "level": "Advanced",
+            "est_time_hrs": 3,
+            "why": "Aggregates research, frameworks, and datasets for graph-enhanced RAG."
+        }
+    ],
+    "Module 05 · Evaluation & Observability": [
+        {
+            "title": "Ragas",
+            "url": "https://github.com/explodinggradients/ragas",
+            "format": "Library",
+            "level": "Intermediate",
+            "est_time_hrs": 4,
+            "why": "Implements retrieval and answer quality metrics with dataset scaffolding."
+        },
+        {
+            "title": "promptfoo",
+            "url": "https://github.com/promptfoo/promptfoo",
+            "format": "CLI",
+            "level": "Intermediate",
+            "est_time_hrs": 3,
+            "why": "Automates prompt regression tests with diff-friendly outputs."
+        },
+        {
+            "title": "Langfuse",
+            "url": "https://github.com/langfuse/langfuse",
+            "format": "Platform",
+            "level": "Intermediate",
+            "est_time_hrs": 5,
+            "why": "Delivers tracing, analytics, and user feedback dashboards for LLM apps."
+        },
+        {
+            "title": "TruLens",
+            "url": "https://github.com/truera/trulens",
+            "format": "Framework",
+            "level": "Intermediate",
+            "est_time_hrs": 4,
+            "why": "Adds evaluator suites and guardrail policies with audit trails."
+        }
+    ],
+    "Evaluation & Evals": [
+        {
+            "title": "InstructEval",
+            "url": "https://github.com/declare-lab/instruct-eval",
+            "format": "Benchmark",
+            "level": "Advanced",
+            "est_time_hrs": 4,
+            "why": "Provides task-specific evaluation datasets for instruction-tuned models."
+        },
+        {
+            "title": "BigCode Evaluation Harness",
+            "url": "https://github.com/bigcode-project/bigcode-evaluation-harness",
+            "format": "Benchmark",
+            "level": "Advanced",
+            "est_time_hrs": 6,
+            "why": "Standardizes code-generation metrics, baselines, and prompts."
+        },
+        {
+            "title": "HELM",
+            "url": "https://github.com/stanford-crfm/helm",
+            "format": "Benchmark",
+            "level": "Advanced",
+            "est_time_hrs": 8,
+            "why": "Offers a broad evaluation framework with safety and efficiency slices."
+        }
+    ],
+    "Module 06 · Serving & Inference": [
+        {
+            "title": "vLLM",
+            "url": "https://github.com/vllm-project/vllm",
+            "format": "Inference engine",
+            "level": "Intermediate",
+            "est_time_hrs": 5,
+            "why": "Teaches paged KV-cache serving with OpenAI-compatible APIs."
+        },
+        {
+            "title": "Text Generation Inference",
+            "url": "https://github.com/huggingface/text-generation-inference",
+            "format": "Inference server",
+            "level": "Intermediate",
+            "est_time_hrs": 5,
+            "why": "Demonstrates managed deployment patterns and streaming responses."
+        },
+        {
+            "title": "TensorRT-LLM",
+            "url": "https://github.com/NVIDIA/TensorRT-LLM",
+            "format": "Toolkit",
+            "level": "Advanced",
+            "est_time_hrs": 6,
+            "why": "Covers GPU-optimized inference, quantization, and serving pipelines."
+        }
+    ],
+    "Module 07 · Performance & Cost Optimization": [
+        {
+            "title": "LLM-AWQ",
+            "url": "https://github.com/mit-han-lab/llm-awq",
+            "format": "Library",
+            "level": "Advanced",
+            "est_time_hrs": 4,
+            "why": "Explains activation-aware quantization with benchmarks."
+        },
+        {
+            "title": "LLM Perf Bench",
+            "url": "https://github.com/mlc-ai/llm-perf-bench",
+            "format": "Benchmark",
+            "level": "Advanced",
+            "est_time_hrs": 5,
+            "why": "Provides scripts to profile latency, throughput, and memory under load."
+        },
+        {
+            "title": "lit-gpt",
+            "url": "https://github.com/Lightning-AI/litgpt",
+            "format": "Framework",
+            "level": "Intermediate",
+            "est_time_hrs": 6,
+            "why": "Combines quantization, LoRA, and efficient serving recipes."
+        }
+    ],
+    "Module 08 · Vector Search": [
+        {
+            "title": "FAISS",
+            "url": "https://github.com/facebookresearch/faiss",
+            "format": "Library",
+            "level": "Intermediate",
+            "est_time_hrs": 6,
+            "why": "Covers index types, IVF parameters, and GPU acceleration."
+        },
+        {
+            "title": "pgvector",
+            "url": "https://github.com/pgvector/pgvector",
+            "format": "Extension",
+            "level": "Intermediate",
+            "est_time_hrs": 4,
+            "why": "Shows how to add vector search to PostgreSQL with hybrid queries."
+        },
+        {
+            "title": "Milvus",
+            "url": "https://github.com/milvus-io/milvus",
+            "format": "Vector database",
+            "level": "Intermediate",
+            "est_time_hrs": 6,
+            "why": "Provides production-scale vector indexing with horizontal scaling."
+        }
+    ],
+    "Module 09 · Security & Safety": [
+        {
+            "title": "OWASP Top 10 for LLM Applications",
+            "url": "https://github.com/OWASP/www-project-top-10-for-large-language-model-applications",
+            "format": "Guide",
+            "level": "Intermediate",
+            "est_time_hrs": 3,
+            "why": "Defines common GenAI threat vectors and mitigations."
+        },
+        {
+            "title": "NeMo Guardrails",
+            "url": "https://github.com/NVIDIA/NeMo-Guardrails",
+            "format": "Framework",
+            "level": "Intermediate",
+            "est_time_hrs": 5,
+            "why": "Implements policy-based guardrails for chat, RAG, and tool agents."
+        },
+        {
+            "title": "Rebuff",
+            "url": "https://github.com/protectai/rebuff",
+            "format": "Toolkit",
+            "level": "Intermediate",
+            "est_time_hrs": 4,
+            "why": "Adds prompt injection detection with sandboxed tool execution."
+        }
+    ],
+    "Security, Privacy & Compliance": [
+        {
+            "title": "AI Privacy Checklist",
+            "url": "https://github.com/JariPesonen/AIPrivacyChecklist",
+            "format": "Checklist",
+            "level": "Intermediate",
+            "est_time_hrs": 2,
+            "why": "Outlines privacy impact questions for model development."
+        },
+        {
+            "title": "AI Privacy Toolkit",
+            "url": "https://github.com/IBM/ai-privacy-toolkit",
+            "format": "Toolkit",
+            "level": "Advanced",
+            "est_time_hrs": 5,
+            "why": "Provides differential privacy utilities and policy templates."
+        },
+        {
+            "title": "AI Compliance Auditor",
+            "url": "https://github.com/awsdataarchitect/ai-compliance-auditor",
+            "format": "Toolkit",
+            "level": "Intermediate",
+            "est_time_hrs": 4,
+            "why": "Demonstrates automated checks for data retention and access controls."
+        }
+    ],
+    "Module 10 · Governance & Compliance": [
+        {
+            "title": "EU AI Act Notes",
+            "url": "https://github.com/daveshap/EU_AI_Act",
+            "format": "Notes",
+            "level": "Intermediate",
+            "est_time_hrs": 4,
+            "why": "Summarizes obligations by risk class with quick reference tables."
+        },
+        {
+            "title": "AI Governance Playbook",
+            "url": "https://github.com/Neetu-kapoor/Ai-governance-playbook",
+            "format": "Playbook",
+            "level": "Intermediate",
+            "est_time_hrs": 3,
+            "why": "Provides governance charters, RACI templates, and stakeholder maps."
+        },
+        {
+            "title": "AI Governance Risk & Compliance Docs",
+            "url": "https://github.com/ahsan-141117/AI-Governance-Risk-Compliance-Documentation",
+            "format": "Templates",
+            "level": "Intermediate",
+            "est_time_hrs": 3,
+            "why": "Includes audit-ready checklists and policy samples for GenAI programs."
+        }
+    ],
+    "Responsible AI & Governance": [
+        {
+            "title": "Awesome Responsible AI",
+            "url": "https://github.com/AthenaCore/AwesomeResponsibleAI",
+            "format": "Curated list",
+            "level": "Intermediate",
+            "est_time_hrs": 6,
+            "why": "Aggregates research, tooling, and case studies on responsible AI."
+        },
+        {
+            "title": "Responsible AI Toolbox",
+            "url": "https://github.com/microsoft/responsible-ai-toolbox",
+            "format": "Toolkit",
+            "level": "Intermediate",
+            "est_time_hrs": 6,
+            "why": "Provides model interpretability, fairness, and error analysis dashboards."
+        },
+        {
+            "title": "Awesome ML Model Governance",
+            "url": "https://github.com/visenger/Awesome-ML-Model-Governance",
+            "format": "Curated list",
+            "level": "Intermediate",
+            "est_time_hrs": 4,
+            "why": "Offers frameworks for lifecycle governance, approvals, and audits."
+        }
+    ],
+    "Module 11 · Edge & Embedded": [
+        {
+            "title": "Edge AI for Beginners",
+            "url": "https://github.com/microsoft/edgeai-for-beginners",
+            "format": "Course",
+            "level": "Intermediate",
+            "est_time_hrs": 10,
+            "why": "Covers hardware-aware deployment and telemetry for small models."
+        },
+        {
+            "title": "ONNX Runtime GenAI",
+            "url": "https://github.com/microsoft/onnxruntime-genai",
+            "format": "Toolkit",
+            "level": "Intermediate",
+            "est_time_hrs": 5,
+            "why": "Shows how to run quantized models on CPU, GPU, and mobile."
+        },
+        {
+            "title": "Phi-3 Mini Samples",
+            "url": "https://github.com/Azure-Samples/Phi-3MiniSamples",
+            "format": "Examples",
+            "level": "Intermediate",
+            "est_time_hrs": 4,
+            "why": "Demonstrates on-device SLM workflows with telemetry capture."
+        }
+    ],
+    "Fine-Tuning & Adapters": [
+        {
+            "title": "PEFT",
+            "url": "https://github.com/huggingface/peft",
+            "format": "Library",
+            "level": "Intermediate",
+            "est_time_hrs": 5,
+            "why": "Implements LoRA, QLoRA, and other parameter-efficient adapters."
+        },
+        {
+            "title": "QLoRA",
+            "url": "https://github.com/artidoro/qlora",
+            "format": "Toolkit",
+            "level": "Advanced",
+            "est_time_hrs": 6,
+            "why": "Explains low-bit fine-tuning with reproducible scripts."
+        },
+        {
+            "title": "Open Instruct",
+            "url": "https://github.com/allenai/open-instruct",
+            "format": "Dataset & recipes",
+            "level": "Advanced",
+            "est_time_hrs": 8,
+            "why": "Provides supervised fine-tuning data pipelines and evaluation baselines."
+        }
+    ],
+    "Multimodal": [
+        {
+            "title": "LLaVA",
+            "url": "https://github.com/haotian-liu/LLaVA",
+            "format": "Model",
+            "level": "Advanced",
+            "est_time_hrs": 6,
+            "why": "Demonstrates visual instruction tuning and captioning workflows."
+        },
+        {
+            "title": "Segment Anything",
+            "url": "https://github.com/facebookresearch/segment-anything",
+            "format": "Model",
+            "level": "Intermediate",
+            "est_time_hrs": 5,
+            "why": "Provides image segmentation building blocks for multimodal agents."
+        },
+        {
+            "title": "Whisper",
+            "url": "https://github.com/openai/whisper",
+            "format": "Model",
+            "level": "Intermediate",
+            "est_time_hrs": 4,
+            "why": "Gives ready-to-run speech transcription pipelines for audio augmentation."
+        }
+    ],
+    "LLMOps & MLE for Leaders": [
+        {
+            "title": "Awesome LLMOps",
+            "url": "https://github.com/tensorchord/Awesome-LLMOps",
+            "format": "Curated list",
+            "level": "Intermediate",
+            "est_time_hrs": 6,
+            "why": "Maps the vendor and open-source landscape for monitoring, deployment, and controls."
+        },
+        {
+            "title": "LLM Engineer's Handbook",
+            "url": "https://github.com/PacktPublishing/LLM-Engineers-Handbook",
+            "format": "Book code",
+            "level": "Intermediate",
+            "est_time_hrs": 10,
+            "why": "Includes project templates, release checklists, and operational metrics."
+        },
+        {
+            "title": "OpenLLMetry",
+            "url": "https://github.com/traceloop/openllmetry",
+            "format": "Toolkit",
+            "level": "Advanced",
+            "est_time_hrs": 5,
+            "why": "Instrument LLM apps with OpenTelemetry for observability and governance."
+        }
+    ],
+    "Module 12 · Portfolio Patterns": [
+        {
+            "title": "GenAI Projects Portfolio",
+            "url": "https://github.com/Ashleshk/GenAI-Projects-Portfolio",
+            "format": "Examples",
+            "level": "Beginner",
+            "est_time_hrs": 3,
+            "why": "Offers portfolio layout ideas with metrics-driven writeups."
+        },
+        {
+            "title": "SAP BTP GenAI Starter Kit",
+            "url": "https://github.com/SAP-samples/btp-genai-starter-kit",
+            "format": "Starter kit",
+            "level": "Intermediate",
+            "est_time_hrs": 6,
+            "why": "Includes production-ready project scaffolds and deployment scripts."
+        },
+        {
+            "title": "AWS Agentic AI Demos",
+            "url": "https://github.com/aws-samples/sample-agentic-ai-demos",
+            "format": "Examples",
+            "level": "Intermediate",
+            "est_time_hrs": 5,
+            "why": "Showcases multi-agent demos with architecture diagrams and KPIs."
+        }
+    ],
+    "Architecture Patterns": [
+        {
+            "title": "Modular RAG",
+            "url": "https://github.com/ThomasVitale/modular-rag",
+            "format": "Guide",
+            "level": "Intermediate",
+            "est_time_hrs": 4,
+            "why": "Breaks RAG systems into repeatable modules with architecture diagrams."
+        },
+        {
+            "title": "LLM Multi-Agent Patterns",
+            "url": "https://github.com/VinZCodz/llm_multi_agent_patterns",
+            "format": "Guide",
+            "level": "Advanced",
+            "est_time_hrs": 4,
+            "why": "Explains when to choose planner/worker, reflection, and critique loops."
+        },
+        {
+            "title": "Kernel Memory",
+            "url": "https://github.com/microsoft/kernel-memory",
+            "format": "Framework",
+            "level": "Intermediate",
+            "est_time_hrs": 5,
+            "why": "Demonstrates memory-first architectures with ingestion, chunking, and retrieval services."
+        }
+    ],
+    "Portfolio & Interview Prep": [
+        {
+            "title": "GenAI Interview Questions",
+            "url": "https://github.com/a-tabaza/genai_interview_questions",
+            "format": "Question bank",
+            "level": "Intermediate",
+            "est_time_hrs": 4,
+            "why": "Curates current GenAI system design and scenario prompts."
+        },
+        {
+            "title": "MLE/DS Interview Prep Guide",
+            "url": "https://github.com/whaleonearth/MLE-DS-Interview-Prep-Guide",
+            "format": "Guide",
+            "level": "Intermediate",
+            "est_time_hrs": 6,
+            "why": "Provides behavioral prompts, take-home tips, and technical refreshers."
+        },
+        {
+            "title": "Andreis Interview Handbook",
+            "url": "https://github.com/andreis/interview",
+            "format": "Guide",
+            "level": "Intermediate",
+            "est_time_hrs": 8,
+            "why": "Gives structured preparation checklists and storytelling frameworks."
+        }
+    ],
+    "Community & Mentoring": [
+        {
+            "title": "Mentorship Guide Docs",
+            "url": "https://github.com/mentorship-sponsorship/mentorship-guide-docs",
+            "format": "Guide",
+            "level": "Beginner",
+            "est_time_hrs": 2,
+            "why": "Explains how to run mentorship agreements and feedback loops."
+        },
+        {
+            "title": "The Open Source Way Guidebook",
+            "url": "https://github.com/theopensourceway/guidebook",
+            "format": "Guidebook",
+            "level": "Intermediate",
+            "est_time_hrs": 6,
+            "why": "Details community-of-practice facilitation and governance tactics."
+        },
+        {
+            "title": "Papers We Love",
+            "url": "https://github.com/papers-we-love/papers-we-love",
+            "format": "Community",
+            "level": "Intermediate",
+            "est_time_hrs": 6,
+            "why": "Models an open study group with reading checklists and meetup templates."
+        }
+    ],
+    "Tooling & Environment Setup": [
+        {
+            "title": "Miniforge",
+            "url": "https://github.com/conda-forge/miniforge",
+            "format": "Installer",
+            "level": "Beginner",
+            "est_time_hrs": 1,
+            "why": "Lightweight conda distribution for reproducible Python environments."
+        },
+        {
+            "title": "VS Code Dev Containers",
+            "url": "https://github.com/microsoft/vscode-dev-containers",
+            "format": "Templates",
+            "level": "Intermediate",
+            "est_time_hrs": 3,
+            "why": "Provides ready-to-use containerized development environments."
+        },
+        {
+            "title": "runpodctl",
+            "url": "https://github.com/runpod/runpodctl",
+            "format": "CLI",
+            "level": "Intermediate",
+            "est_time_hrs": 2,
+            "why": "Helps manage on-demand GPU pods for cloud training and inference."
+        }
+    ]
+}
+
+with open("RESOURCES.json", "w") as f:
+    json.dump(resources, f, indent=2)


### PR DESCRIPTION
## Summary
- add project brief, model card, and experiment log templates to anchor leadership deliverables
- publish contributing guide, code of conduct, roadmap, and machine-readable resource index that align with the revamped README
- add helper script for regenerating the resource catalog

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68e2df9cda80832db723a58cc9e18a38